### PR TITLE
Add redis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ TODO
 - [x] Hello World
 - [x] PostgreSQL
 - [ ] MySQL
-- [ ] Redis
+- [x] Redis
 - [ ] ...
 
 ## Contributing

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,5 +2,6 @@
   imports = [
     ./hello.nix
     ./postgres.nix
+    ./redis.nix
   ];
 }

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -72,7 +72,6 @@ with lib;
 
           export REDISDATA=${cfg.dataDir}
 
-
           if [[ ! -d "$REDISDATA" ]]; then
             mkdir -p "$REDISDATA"
           fi

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -1,0 +1,100 @@
+# Based on https://github.com/cachix/devenv/blob/main/src/modules/services/redis.nix
+{ pkgs, lib, config, ... }:
+
+with lib;
+
+{
+  options.services.redis = {
+    description = ''
+      Enable redis server
+    '';
+    default = { };
+    type = lib.types.submodule ({ config, ... }: {
+      options = {
+        enable = lib.mkEnableOption "redis";
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = "redis";
+          description = "Unique process name";
+        };
+
+        package = lib.mkPackageOption pkgs "redis" { };
+
+        dataDir = lib.mkOption {
+          type = lib.types.str;
+          default = "./data/${config.name}";
+          description = "The redis data directory";
+        };
+
+        bind = mkOption {
+          type = types.nullOr types.str;
+          default = "127.0.0.1";
+          description = ''
+            The IP interface to bind to.
+            `null` means "all interfaces".
+          '';
+          example = "127.0.0.1";
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 6379;
+          description = ''
+            The TCP port to accept connections.
+            If port 0 is specified Redis, will not listen on a TCP socket.
+          '';
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = "Additional text to be appended to `redis.conf`.";
+        };
+      };
+    });
+
+  };
+
+  config = let cfg = config.services.redis; in lib.mkIf cfg.enable {
+
+    settings.processes.redis = 
+    let
+      redisConfig = pkgs.writeText "redis.conf" ''
+        port ${toString cfg.port}
+        ${optionalString (cfg.bind != null) "bind ${cfg.bind}"}
+        ${cfg.extraConfig}
+      '';
+
+      startScript = pkgs.writeShellScriptBin "start-redis" ''
+        set -euo pipefail
+
+        export REDISDATA=${cfg.dataDir}
+
+
+        if [[ ! -d "$REDISDATA" ]]; then
+          mkdir -p "$REDISDATA"
+        fi
+
+        exec ${cfg.package}/bin/redis-server ${redisConfig} --dir "$REDISDATA"
+      '';
+    in
+    {
+      exec = "${startScript}/bin/start-redis";
+
+      process-compose = {
+        readiness_probe = {
+          exec.command = "${cfg.package}/bin/redis-cli -p ${toString cfg.port} ping";
+          initial_delay_seconds = 2;
+          period_seconds = 10;
+          timeout_seconds = 4;
+          success_threshold = 1;
+          failure_threshold = 5;
+        };
+
+        # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
+        availability.restart = "on_failure";
+      };
+    };
+  };
+}

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -42,7 +42,8 @@ with lib;
           default = 6379;
           description = ''
             The TCP port to accept connections.
-            If port 0 is specified Redis, will not listen on a TCP socket.
+
+            If port is set to `0`, redis will not listen on a TCP socket.
           '';
         };
 

--- a/nix/redis_test.nix
+++ b/nix/redis_test.nix
@@ -1,0 +1,10 @@
+{ config, ... }: {
+  services.redis.enable = true;
+  testScript = ''
+    process_compose.wait_until(lambda procs:
+      # TODO: Check for 'ready'
+      procs["redis"]["status"] == "Running"
+    )
+    machine.succeed("${config.services.redis.package}/bin/redis-cli ping | grep -q 'PONG'")
+  '';
+}

--- a/nix/redis_test.nix
+++ b/nix/redis_test.nix
@@ -2,7 +2,7 @@
   services.redis.enable = true;
   testScript = ''
     process_compose.wait_until(lambda procs:
-      # TODO: Check for 'ready'
+      # TODO: Check for 'is_ready' instead of 'status'
       procs["redis"]["status"] == "Running"
     )
     machine.succeed("${config.services.redis.package}/bin/redis-cli ping | grep -q 'PONG'")

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -18,8 +18,13 @@
             imports = [
               inputs.services-flake.processComposeModules.default
               ../nix/postgres_test.nix
-              ../nix/redis_test.nix
             ];
+          };
+          redis = {
+              imports = [
+                inputs.services-flake.processComposeModules.default
+                ../nix/redis_test.nix
+              ];
           };
         };
       };

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -21,10 +21,10 @@
             ];
           };
           redis = {
-              imports = [
-                inputs.services-flake.processComposeModules.default
-                ../nix/redis_test.nix
-              ];
+            imports = [
+              inputs.services-flake.processComposeModules.default
+              ../nix/redis_test.nix
+            ];
           };
         };
       };

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -18,6 +18,7 @@
             imports = [
               inputs.services-flake.processComposeModules.default
               ../nix/postgres_test.nix
+              ../nix/redis_test.nix
             ];
           };
         };


### PR DESCRIPTION
Resolves #6 
Example:
```nix
# Inside perSystem
{
  # This adds a `self.packages.default`
  process-compose."default" = { config, ... }:
    {
       imports = [
         inputs.services-flake.processComposeModules.default
       ];
       # Starts redis server on port 6379 with data directory in ./data/redis
       services.redis.enable = true;
    };
}
```
TODO:
- [x] Add NixOS test