### PR TITLE
Revert "dev flake: check example and tests"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,1 @@
-use flake ./dev \
-    --override-input services-flake . \
-    --override-input example ./example \
-    --override-input example/services-flake .
+use flake ./dev

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ NixOS-like services for Nix flakes, as a [process-compose-flake](https://github.
 
 TODO
 
-- Use direnv to enter the devShell
-- Add tests to `./dev/flake.nix`
+(But see `./test/flake.nix`)
 
 ## Services available
 

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,18 +1,9 @@
-# Development flake
-#
-# We setup a dev environment as well as run tests (flake checks) here, such that
-# the top-level flake is simple enough for users.
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
     mission-control.url = "github:Platonic-Systems/mission-control";
-
-    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
-    services-flake.url = "path:..";
-    example.url = "path:../example";
-
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -20,28 +11,8 @@
       imports = [
         inputs.flake-root.flakeModule
         inputs.mission-control.flakeModule
-        inputs.process-compose-flake.flakeModule
       ];
-      perSystem = { inputs', pkgs, lib, config, ... }: {
-        # Test /example
-        checks = inputs'.example.checks;
-
-        # Test the individual services
-        process-compose = {
-          postgres = {
-            imports = [
-              inputs.services-flake.processComposeModules.default
-              ../nix/postgres_test.nix
-            ];
-          };
-          redis = {
-            imports = [
-              inputs.services-flake.processComposeModules.default
-              ../nix/redis_test.nix
-            ];
-          };
-        };
-
+      perSystem = { pkgs, lib, config, ... }: {
         mission-control.scripts = {
           ex = {
             description = "Run example";

--- a/test.sh
+++ b/test.sh
@@ -2,8 +2,11 @@ set -euxo pipefail
 
 cd "$(dirname "$0")"
 
-# TODO: use github:srid/nixci
-nix flake check -L ./dev \
-    --override-input services-flake . \
-    --override-input example ./example \
-    --override-input example/services-flake .
+# On NixOS, run the VM tests to test runtime behaviour
+if command -v nixos-rebuild &> /dev/null; then
+  # example test
+  nix flake check -L ./example --override-input services-flake .
+
+  # service tests
+  nix flake check -L ./test --override-input services-flake .
+fi

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -1,0 +1,112 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1686089707,
+        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "process-compose-flake": {
+      "locked": {
+        "lastModified": 1687298948,
+        "narHash": "sha256-7Lu4/odCkkwrzR8Mo+3D+URv4oLap8WWLESzi/75eb0=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "5bdb90b85642901cf9a5dccfe8c907091c261604",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "process-compose-flake": "process-compose-flake",
+        "services-flake": "services-flake",
+        "systems": "systems"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1687211778,
+        "narHash": "sha256-eBO71ucbGhNX7095CsFDm+sQ/HuTJSy03S3MevWVuZw=",
+        "owner": "juspay",
+        "repo": "services-flake",
+        "rev": "f171932d130c3ce5184b69144012a225b2e28868",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "services-flake",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    services-flake.url = "github:juspay/services-flake";
+  };
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+      imports = [
+        inputs.process-compose-flake.flakeModule
+      ];
+      perSystem = { self', pkgs, lib, ... }: {
+        process-compose = {
+          postgres = {
+            imports = [
+              inputs.services-flake.processComposeModules.default
+              ../nix/postgres_test.nix
+            ];
+          };
+          redis = {
+            imports = [
+              inputs.services-flake.processComposeModules.default
+              ../nix/redis_test.nix
+            ];
+          };
+        };
+      };
+    };
+}


### PR DESCRIPTION
Reverts juspay/services-flake#16

Actually, it is better to keep this all _decoupled_ and separate (for simplicity), especially I've arrived at a design for `nixci` where it can/will support building _multiple_ sub-flakes.