### PR TITLE
Add `nixci` config to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,12 +8,17 @@
     };
 
     # Config for https://github.com/srid/nixci
-    nixci = {
-      flakeDir = "./dev";
-      overrideInputs = rec {
-        "services-flake" = ".";
-        "example" = "./example";
-        "example/services-flake" = services-flake;
+    nixci = let overrideInputs = { "services-flake" = "."; }; in {
+      example = {
+        inherit overrideInputs;
+        dir = "./example";
+      };
+      test = {
+        inherit overrideInputs;
+        dir = "./test";
+      };
+      dev = {
+        dir = "./dev";
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,10 @@
 
     nixci = {
       flakeDir = "./dev";
+      overrideInputs = {
+        "services-flake" = ".";
+        "example" = "./example";
+      };
     };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,10 @@
 
     nixci = {
       flakeDir = "./dev";
-      overrideInputs = {
+      overrideInputs = rec {
         "services-flake" = ".";
         "example" = "./example";
+        "example/services-flake" = services-flake;
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
       path = builtins.path { path = ./example; filter = path: _: baseNameOf path == "flake.nix"; };
     };
 
+    # Config for https://github.com/srid/nixci
     nixci = {
       flakeDir = "./dev";
       overrideInputs = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     };
 
     # Config for https://github.com/srid/nixci
+    # To run this, `nix run github:srid/nixci`
     nixci = let overrideInputs = { "services-flake" = ./.; }; in {
       example = {
         inherit overrideInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -6,5 +6,9 @@
       description = "Example flake using process-compose-flake";
       path = builtins.path { path = ./example; filter = path: _: baseNameOf path == "flake.nix"; };
     };
+
+    nixci = {
+      flakeDir = "./dev";
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     };
 
     # Config for https://github.com/srid/nixci
-    nixci = let overrideInputs = { "services-flake" = "."; }; in {
+    nixci = let overrideInputs = { "services-flake" = ./.; }; in {
       example = {
         inherit overrideInputs;
         dir = "./example";

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,8 @@ set -euxo pipefail
 
 cd "$(dirname "$0")"
 
+# TODO: Replace this with `nix run github:srid/nixci`
+
 # On NixOS, run the VM tests to test runtime behaviour
 if command -v nixos-rebuild &> /dev/null; then
   # example test


### PR DESCRIPTION
We're not using it yet, because nixci is yet to be stable.

To test, run `nix run github:srid/nixci` at project root.