### PR TITLE
Use `just` for deterministic `dataDir` in Nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ TODO
 - [x] Redis
 - [ ] ...
 
+## A note on process working directory
+
+The `dataDir` of these services tend to take *relative* paths, which are usually relative to the project root. As such, when you run these services using `nix run`, their data files are created relative to whichever directory you are in. If you want these data files to always reside relative to the project directory, instead of using `nix run` consider wrapping the process-compose packages in script, via either [mission-control](https://zero-to-flakes.com/mission-control/) module or a [justfile](https://just.systems/). The example uses the latter.
+
 ## Contributing
 
 - If you are adding a *new* service, see https://github.com/cachix/devenv/tree/main/src/modules/services for inspiration.

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -33,21 +33,6 @@
         "type": "github"
       }
     },
-    "mission-control": {
-      "locked": {
-        "lastModified": 1683658484,
-        "narHash": "sha256-JkGnWyYZxOnyOhztrxLSqaod6+O/3rRypq0dAqA/zn0=",
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
-        "rev": "a0c93bd764a3c25e6999397e9f5f119c1b124e38",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Platonic-Systems",
-        "repo": "mission-control",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1687274257,
@@ -102,7 +87,6 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
-        "mission-control": "mission-control",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -3,7 +3,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
-    mission-control.url = "github:Platonic-Systems/mission-control";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
@@ -11,7 +10,6 @@
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
         inputs.flake-root.flakeModule
-        inputs.mission-control.flakeModule
         inputs.treefmt-nix.flakeModule
       ];
       perSystem = { pkgs, lib, config, ... }: {
@@ -21,23 +19,14 @@
             nixpkgs-fmt.enable = true;
           };
         };
-        mission-control.scripts = {
-          ex = {
-            description = "Run example";
-            exec = "cd ./example && nix run . --override-input services-flake ..";
-          };
-          test = {
-            description = "Run test";
-            exec = "./test.sh";
-          };
-          fmt = {
-            description = "Format all Nix files";
-            exec = config.treefmt.build.wrapper;
-          };
-        };
         devShells.default = pkgs.mkShell {
-          # cf. https://haskell.flake.page/devshell#composing-devshells
-          inputsFrom = [ config.mission-control.devShell ];
+          nativeBuildInputs = [
+            pkgs.just
+          ];
+          # cf. https://zero-to-flakes.com/haskell-flake/devshell#composing-devshells
+          inputsFrom = [
+            config.treefmt.build.devShell
+          ];
         };
       };
     };

--- a/example/.envrc
+++ b/example/.envrc
@@ -1,0 +1,1 @@
+use flake . --override-input services-flake path:../.

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -63,6 +63,10 @@
               machine.succeed("echo 'SELECT version();' | ${config.services.postgres.pg1.package}/bin/psql -h 127.0.0.1 -U tester ${dbName}")
             '';
           };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [ pkgs.just ];
+        };
       };
     };
 }

--- a/example/justfile
+++ b/example/justfile
@@ -1,0 +1,2 @@
+default:
+    nix run

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+default:
+    @just --list
+
+# Run example
+ex:
+    cd ./example && nix run . --override-input services-flake ..
+
+# Auto-format the project tree
+fmt:
+    treefmt


### PR DESCRIPTION
First, this PR switches the dev flake from mission-control to [just](https://github.com/casey/just) similar to https://github.com/srid/haskell-template/pull/111

Then, we introduce `justfile` under the example flake. Now if you do,

```sh
cd ./example
mkdir foo 
cd ./foo
nix run
```

The data directory will be created under `./example/foo` which is unexpected. Whereas, the following would always create it in `./example`:

```sh
cd ./example
mkdir foo 
cd ./foo
just
```

Unless `[no-cd]` is used, [just](https://github.com/casey/just#recipe-parameters) will always cd to the directory where the `justfile` lives. 

The README documents this, as a sufficient solution such that it resolves #26.