### PR TITLE
Add Redis cluster service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ TODO
 - [x] PostgreSQL
 - [ ] MySQL
 - [x] Redis
+- [x] Redis Cluster
 - [ ] ...
 
 ## A note on process working directory

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,5 +36,6 @@ in
   imports = builtins.map multiService [
     ./postgres.nix
     ./redis.nix
+    ./redis-cluster.nix
   ];
 }

--- a/nix/postgres.nix
+++ b/nix/postgres.nix
@@ -343,7 +343,7 @@ in
 
                 initdbArgs =
                   config.initdbArgs
-                  ++ (lib.optionals (config.superuser != null) ["-U" config.superuser]);
+                  ++ (lib.optionals (config.superuser != null) [ "-U" config.superuser ]);
 
                 setupScript = pkgs.writeShellScriptBin "setup-postgres" ''
                   set -euo pipefail

--- a/nix/redis-cluster.nix
+++ b/nix/redis-cluster.nix
@@ -1,0 +1,145 @@
+{ pkgs, lib, name, config, ... }:
+let
+  inherit (lib) types;
+in
+{
+  options = {
+    enable = lib.mkEnableOption name;
+
+    package = lib.mkPackageOption pkgs "redis" { };
+
+    dataDir = lib.mkOption {
+      type = types.str;
+      default = "./data/${name}";
+      description = "The redis-cluster data directory (common for all nodes).";
+    };
+
+    port = lib.mkOption {
+      type = types.port;
+      default = 30001;
+      description = ''
+        The TCP port to accept connections.
+
+        Next node will use the next port and so on.
+
+        If port is set to `0`, redis will not listen on a TCP socket.
+      '';
+    };
+
+    bind = lib.mkOption {
+      type = types.nullOr types.str;
+      default = "127.0.0.1";
+      description = ''
+        The IP interface to bind to.
+        `null` means "all interfaces".
+
+        All the nodes will follow the same bind address.
+      '';
+      example = "127.0.0.1";
+    };
+
+    timeout = lib.mkOption {
+      type = types.int;
+      default = 2000;
+      description = ''
+        Time (in milliseconds) after which the node is considered to be down.
+
+        If master node is down, a replica node will take over.
+      '';
+    };
+
+    nodes = lib.mkOption {
+      type = types.int;
+      default = 6;
+      description = ''
+        Number of nodes in the cluster.
+      '';
+    };
+
+    replicas = lib.mkOption {
+      type = types.int;
+      default = 1;
+      description = ''
+        Number of replicas per Master node.
+      '';
+    };
+
+    extraConfigs = lib.mkOption {
+      type = types.attrsOf types.lines;
+      default = { };
+      description = "Attrset map of node (identified by port number) to the respective `redis.conf`.";
+      example = ''
+        {
+          {
+            30001 = "port 30001";
+          };
+        }
+      '';
+    };
+
+    outputs.settings = lib.mkOption {
+      type = types.deferredModule;
+      internal = true;
+      readOnly = true;
+      default =
+        let
+          hosts = lib.genList (x: "${config.bind}:${builtins.toString(config.port + x)}") config.nodes;
+          ports = lib.genList (x: "${builtins.toString(config.port + x)}") config.nodes;
+          healthyNodes = lib.genAttrs ports (port: { condition = "process_healthy"; });
+          node = port:
+            let
+              redisConfig = pkgs.writeText "redis.conf" ''
+                port ${port}
+                cluster-enabled yes
+                cluster-config-file nodes-${port}.conf
+                cluster-node-timeout ${builtins.toString config.timeout}
+                appendonly yes
+                appendfilename "appendonly-${port}.aof"
+                dbfilename "dump-${port}.rdb"
+
+                ${lib.optionalString (config.bind != null) "bind ${config.bind}"}
+                ${lib.optionalString (builtins.hasAttr port config.extraConfigs) "${config.extraConfigs.${port}}"}
+              '';
+
+              startScript = pkgs.writeShellScriptBin "start-redis" ''
+                set -euo pipefail
+
+                export REDISDATA=${config.dataDir}
+
+                if [[ ! -d "$REDISDATA" ]]; then
+                  mkdir -p "$REDISDATA"
+                fi
+
+                exec ${config.package}/bin/redis-server ${redisConfig} --dir "$REDISDATA"
+              '';
+            in
+            {
+              command = "${startScript}/bin/start-redis";
+              shutdown.command = "${config.package}/bin/redis-cli -p ${port} shutdown nosave";
+
+              readiness_probe = {
+                exec.command = "${config.package}/bin/redis-cli -p ${port} ping";
+                initial_delay_seconds = 2;
+                period_seconds = 10;
+                timeout_seconds = 4;
+                success_threshold = 1;
+                failure_threshold = 5;
+              };
+
+              # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
+              availability.restart = "on_failure";
+            };
+        in
+        {
+          processes = lib.genAttrs ports (port: node port) //
+            {
+              "cluster-create" = {
+
+                depends_on = healthyNodes;
+                command = "${config.package}/bin/redis-cli --cluster create ${lib.concatStringsSep " " hosts} --cluster-replicas ${builtins.toString config.replicas} --cluster-yes";
+              };
+            };
+        };
+    };
+  };
+}

--- a/nix/redis-cluster.nix
+++ b/nix/redis-cluster.nix
@@ -119,12 +119,11 @@ in
               availability.restart = "on_failure";
             };
           hosts = lib.mapAttrsToList (_: cfg: "${config.bind}:${builtins.toString cfg.port}") config.nodes;
-          healthyNodes = lib.mapAttrs' (nodeName: cfg: lib.nameValuePair "${name}-${nodeName}" { condition = "process_healthy"; }) config.nodes;
         in
         {
           processes = (lib.mapAttrs' mkNodeProcess config.nodes) // {
             "${name}-cluster-create" = {
-              depends_on = healthyNodes;
+              depends_on = lib.mapAttrs' (nodeName: cfg: lib.nameValuePair "${name}-${nodeName}" { condition = "process_healthy"; }) config.nodes;
               command = "${config.package}/bin/redis-cli --cluster create ${lib.concatStringsSep " " hosts} --cluster-replicas ${builtins.toString config.replicas} --cluster-yes";
             };
           };

--- a/nix/redis-cluster_test.nix
+++ b/nix/redis-cluster_test.nix
@@ -1,0 +1,15 @@
+{ config, ... }: {
+  services.redis-cluster."c1".enable = true;
+  testScript = ''
+    process_compose.wait_until(lambda procs:
+      # TODO: Check for 'is_ready' instead of 'status'
+      procs["c1-cluster-create"]["status"] == "Completed"
+    )
+    machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30001 ping | grep -q 'PONG'")
+    machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30002 ping | grep -q 'PONG'")
+    machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30003 ping | grep -q 'PONG'")
+    machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30004 ping | grep -q 'PONG'")
+    machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30005 ping | grep -q 'PONG'")
+    machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30006 ping | grep -q 'PONG'")
+  '';
+}

--- a/nix/redis-cluster_test.nix
+++ b/nix/redis-cluster_test.nix
@@ -2,7 +2,8 @@
   services.redis-cluster."c1".enable = true;
   testScript = ''
     process_compose.wait_until(lambda procs:
-      # TODO: Check for 'is_ready' of `c1-cluster-create` instead of `c1-n1`. This should be easy after https://github.com/juspay/services-flake/issues/32
+      # TODO: Check for 'is_ready' of `c1-cluster-create` instead of `c1-n1` (status of `c1-cluster-create` determines whether the hashslots are assigned). 
+      #       This should be easy after https://github.com/juspay/services-flake/issues/32
       procs["c1-n1"]["status"] == "Running"
     )
     machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30001 ping | grep -q 'PONG'")

--- a/nix/redis-cluster_test.nix
+++ b/nix/redis-cluster_test.nix
@@ -2,8 +2,8 @@
   services.redis-cluster."c1".enable = true;
   testScript = ''
     process_compose.wait_until(lambda procs:
-      # TODO: Check for 'is_ready' instead of 'status'
-      procs["c1-cluster-create"]["status"] == "Completed"
+      # TODO: Check for 'is_ready' of `c1-cluster-create` instead of `c1-n1`. This should be easy after https://github.com/juspay/services-flake/issues/32
+      procs["c1-n1"]["status"] == "Running"
     )
     machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30001 ping | grep -q 'PONG'")
     machine.succeed("${config.services.redis-cluster.c1.package}/bin/redis-cli -p 30002 ping | grep -q 'PONG'")

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -26,6 +26,12 @@
               ../nix/redis_test.nix
             ];
           };
+          redis-cluster = {
+            imports = [
+              inputs.services-flake.processComposeModules.default
+              ../nix/redis-cluster_test.nix
+            ];
+          };
         };
       };
     };


### PR DESCRIPTION
Closes #15 

`create-cluster` shell script provided by `redis` includes a sub-command to clean all the nodes, which is just removing all the files from the data directory. We can ignore that and maybe just add it under "How to" section in doc.

Example:

```
# Inside perSystem
{
  # This adds a `self.packages.default`
  process-compose."default" = { config, ... }:
    {
       imports = [
         inputs.services-flake.processComposeModules.default
       ];
       # Starts redis cluster service with nodes on 30001, 30002, 30004, 30005 and 30006 ports respectively.
       services.redis-cluster."cluster1".enable = true;
    };
}
```

TODO:
- [x] Add NixOS test