### PR TITLE
Remove `port = 0;` attribute for test processes

### DIFF
--- a/test/flake.nix
+++ b/test/flake.nix
@@ -15,22 +15,18 @@
       perSystem = { self', pkgs, lib, ... }: {
         process-compose = {
           postgres = {
-            # TODO: remove `port = 0`; as it will be default after this: https://github.com/Platonic-Systems/process-compose-flake/pull/42
-            port = 0;
             imports = [
               inputs.services-flake.processComposeModules.default
               ../nix/postgres_test.nix
             ];
           };
           redis = {
-            port = 0;
             imports = [
               inputs.services-flake.processComposeModules.default
               ../nix/redis_test.nix
             ];
           };
           redis-cluster = {
-            port = 0;
             imports = [
               inputs.services-flake.processComposeModules.default
               ../nix/redis-cluster_test.nix


### PR DESCRIPTION
This is set by default in `process-compose-flake` after https://github.com/Platonic-Systems/process-compose-flake/pull/42