### PR TITLE
Namespaces

### DIFF
--- a/example/flake.lock
+++ b/example/flake.lock
@@ -70,15 +70,16 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1693927910,
-        "narHash": "sha256-qPKHnWWzHS2bAi/SsFePQkGFeC2E1jklUjEidfQwYLc=",
-        "owner": "Platonic-Systems",
+        "lastModified": 1695980677,
+        "narHash": "sha256-5tHNbk0ldLUjAqKRZog/3asiVvkD51VGK9TvwzUBs38=",
+        "owner": "shivaraj-bh",
         "repo": "process-compose-flake",
-        "rev": "5494afa0b6a7bc4ccf82ef1c36fe1fcdb4217255",
+        "rev": "cad5d70f52727ed0a828b69a7e9949f925585b99",
         "type": "github"
       },
       "original": {
-        "owner": "Platonic-Systems",
+        "owner": "shivaraj-bh",
+        "ref": "namespace",
         "repo": "process-compose-flake",
         "type": "github"
       }

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -70,16 +70,15 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1695980677,
+        "lastModified": 1695992918,
         "narHash": "sha256-5tHNbk0ldLUjAqKRZog/3asiVvkD51VGK9TvwzUBs38=",
-        "owner": "shivaraj-bh",
+        "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "cad5d70f52727ed0a828b69a7e9949f925585b99",
+        "rev": "1ebecb83f15736f5d4ae3feb01a8391977dd71da",
         "type": "github"
       },
       "original": {
-        "owner": "shivaraj-bh",
-        "ref": "namespace",
+        "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
         "type": "github"
       }

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -4,7 +4,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
-    process-compose-flake.url = "github:shivaraj-bh/process-compose-flake/namespace";
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
 
     northwind.url = "github:pthom/northwind_psql";

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -4,7 +4,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
-    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    process-compose-flake.url = "github:shivaraj-bh/process-compose-flake/namespace";
     services-flake.url = "github:juspay/services-flake";
 
     northwind.url = "github:pthom/northwind_psql";

--- a/nix/apache-kafka.nix
+++ b/nix/apache-kafka.nix
@@ -144,6 +144,7 @@ with lib;
                 success_threshold = 1;
                 failure_threshold = 5;
               };
+              namespace = name;
 
               availability.restart = "on_failure";
             };

--- a/nix/elasticsearch.nix
+++ b/nix/elasticsearch.nix
@@ -188,6 +188,7 @@ in
               success_threshold = 1;
               failure_threshold = 5;
             };
+            namespace = name;
 
             # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
             availability.restart = "on_failure";

--- a/nix/mysql.nix
+++ b/nix/mysql.nix
@@ -260,12 +260,14 @@ in
                   success_threshold = 1;
                   failure_threshold = 5;
                 };
+                namespace = name;
 
                 # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
                 availability.restart = "on_failure";
               };
             "${name}-configure" = {
               command = "${configureScript}/bin/configure-mysql";
+              namespace = name;
               depends_on."${name}".condition = "process_healthy";
             };
           };

--- a/nix/postgres.nix
+++ b/nix/postgres.nix
@@ -269,7 +269,7 @@ in
         {
           processes = {
             # DB initialization
-            "${name}-init".command =
+            "${name}-init" =
               let
                 setupInitialDatabases =
                   if config.initialDatabases != [ ] then
@@ -368,10 +368,13 @@ in
                   cp ${configFile} "$PGDATA/postgresql.conf"
                 '';
               in
-              ''
-                export PGDATA="${config.dataDir}"
-                ${lib.getExe setupScript}
-              '';
+              {
+                command = ''
+                  export PGDATA="${config.dataDir}"
+                  ${lib.getExe setupScript}
+                '';
+                namespace = name;
+              };
 
             # DB process
             ${name} =
@@ -405,6 +408,7 @@ in
                   success_threshold = 1;
                   failure_threshold = 5;
                 };
+                namespace = name;
                 # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
                 availability.restart = "on_failure";
               };

--- a/nix/redis-cluster.nix
+++ b/nix/redis-cluster.nix
@@ -114,6 +114,7 @@ in
                 success_threshold = 1;
                 failure_threshold = 5;
               };
+              namespace = name;
 
               # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
               availability.restart = "on_failure";
@@ -125,6 +126,7 @@ in
             "${name}-cluster-create" = {
               depends_on = lib.mapAttrs' (nodeName: cfg: lib.nameValuePair "${name}-${nodeName}" { condition = "process_healthy"; }) config.nodes;
               command = "${config.package}/bin/redis-cli --cluster create ${lib.concatStringsSep " " hosts} --cluster-replicas ${builtins.toString config.replicas} --cluster-yes";
+              namespace = name;
             };
           };
         };

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -78,6 +78,7 @@ in
                 success_threshold = 1;
                 failure_threshold = 5;
               };
+              namespace = name;
 
               # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
               availability.restart = "on_failure";

--- a/nix/zookeeper.nix
+++ b/nix/zookeeper.nix
@@ -144,6 +144,7 @@ with lib;
                 success_threshold = 1;
                 failure_threshold = 5;
               };
+              namespace = name;
 
               availability.restart = "on_failure";
             };

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -54,11 +54,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1693927910,
-        "narHash": "sha256-qPKHnWWzHS2bAi/SsFePQkGFeC2E1jklUjEidfQwYLc=",
+        "lastModified": 1695992918,
+        "narHash": "sha256-5tHNbk0ldLUjAqKRZog/3asiVvkD51VGK9TvwzUBs38=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "5494afa0b6a7bc4ccf82ef1c36fe1fcdb4217255",
+        "rev": "1ebecb83f15736f5d4ae3feb01a8391977dd71da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes #46 

Question: Won't it be repetitive to have the process name and namespace present the same info? For instance in the screenshot below, `pg1` and `pg1-init` are grouped together under `pg1` namespace, which is the intended behaviour, but doesn't it look like there are too many `pg1's`.
<img width="1087" alt="Screenshot 2023-09-29 at 3 28 18 PM" src="https://github.com/juspay/services-flake/assets/23645788/5b54637c-8437-4ee5-8685-fa66221c7525">

TODO:
- [x] Change process-compose-flake input to upstream post this [PR](https://github.com/Platonic-Systems/process-compose-flake/pull/45).
- Use [this](https://github.com/F1bonacc1/process-compose/blob/5d7d23deca386ea456d76effb594a7c326643375/README.md?plain=1#L683-L686) to create a small clip and demonstrate how to start selective namespaces, when others aren't needed.