### PR TITLE
[Postgres]: Use `schemas` in-place of `initialDumps`

### DIFF
--- a/example/flake.nix
+++ b/example/flake.nix
@@ -33,7 +33,7 @@
               initialDatabases = [
                 {
                   name = dbName;
-                  schema = "${inputs.northwind}/northwind.sql";
+                  schemas = [ "${inputs.northwind}/northwind.sql" ];
                 }
               ];
             };

--- a/nix/postgres/default.nix
+++ b/nix/postgres/default.nix
@@ -204,11 +204,11 @@ in
               The name of the database to create.
             '';
           };
-          schema = lib.mkOption {
-            type = types.nullOr types.path;
+          schemas = lib.mkOption {
+            type = types.nullOr (types.listOf types.path);
             default = null;
             description = ''
-              The initial schema of the database; if null (the default),
+              The initial list of schemas for the database; if null (the default),
               an empty database is created.
             '';
           };
@@ -223,7 +223,7 @@ in
         [
           {
             name = "foodatabase";
-            schema = ./foodatabase.sql;
+            schemas = [ ./fooschemas ./bar.sql ];
           }
           { name = "bardatabase"; }
         ]
@@ -246,16 +246,6 @@ in
         };
       }));
       default = null;
-    };
-
-    initialDumps = lib.mkOption {
-      type = types.listOf types.path;
-      default = [ ];
-      description = ''List of SQL dumps to run during the database initialization.
-      These dumps are loaded after `initalScript` and `initialDatabases`.'';
-      example = lib.literalExpression ''
-        [ ./foo.sql ./bar.sql ]
-      '';
     };
 
     initialScript = lib.mkOption {

--- a/nix/postgres/postgres_test.nix
+++ b/nix/postgres/postgres_test.nix
@@ -34,7 +34,7 @@
           # initialScript.after test
           echo "SELECT 1 FROM pg_database WHERE datname = 'foo';" | psql -h 127.0.0.1 | grep -q 1
 
-          #intialDumps test
+          # schemas test
           echo "SELECT * from users where user_name = 'test_user';" | psql -h 127.0.0.1 -p 5433 -d sample-db | grep -q test_user
         '';
         name = "postgres-test";

--- a/nix/postgres/postgres_test.nix
+++ b/nix/postgres/postgres_test.nix
@@ -4,7 +4,18 @@
     listen_addresses = "127.0.0.1";
     initialScript.before = "CREATE USER bar;";
     initialScript.after = "CREATE DATABASE foo OWNER bar;";
-    initialDumps = [ ./test.sql ];
+  };
+  services.postgres."pg2" = {
+    enable = true;
+    port = 5433;
+    listen_addresses = "127.0.0.1";
+    # INFO: pg1 creates $USER database while pg2 doesn't because `initialDatabases` is present
+    initialDatabases = [
+      {
+        name = "sample-db";
+        schemas = [ ./test.sql ];
+      }
+    ];
   };
   settings.processes.test =
     let
@@ -24,7 +35,7 @@
           echo "SELECT 1 FROM pg_database WHERE datname = 'foo';" | psql -h 127.0.0.1 | grep -q 1
 
           #intialDumps test
-          echo "SELECT * from users where user_name = 'test_user';" | psql -h 127.0.0.1 -d postgres | grep -q test_user
+          echo "SELECT * from users where user_name = 'test_user';" | psql -h 127.0.0.1 -p 5433 -d sample-db | grep -q test_user
         '';
         name = "postgres-test";
       };


### PR DESCRIPTION
## Problem

`initialDumps` is always created under `postgres` database, which is not a desirable default behaviour when your dumps are intended for different database, like [`atlas_dev` in nammayatri](https://github.com/nammayatri/nammayatri/blob/2e20e20b89591501b32743c4cfe52b24dd1aabda/Backend/nix/arion-configuration.nix#L49).

## Solution

We already have [schema](https://github.com/juspay/services-flake/blob/2211042f3e04de6b105f8d70c0be6213a2127d88/nix/postgres/default.nix#L207-L214) module option to load a schema into a given [database name](https://github.com/juspay/services-flake/blob/2211042f3e04de6b105f8d70c0be6213a2127d88/nix/postgres/default.nix#L201-L206). The schema module option already supports loading from either a file or all the [`.sql` files in a folder.](https://github.com/juspay/services-flake/blob/2211042f3e04de6b105f8d70c0be6213a2127d88/nix/postgres/setup-script.nix#L31-L33) 

The sql dumps in some cases can be [scattered across folders](https://github.com/nammayatri/nammayatri/blob/2e20e20b89591501b32743c4cfe52b24dd1aabda/Backend/nix/arion-configuration.nix#L23-L38), and hence we can rename `schema` to `schemas` and allow it. 


Tagging @rsrohitsingh682 here as he had worked on [`initialDumps`](https://github.com/juspay/services-flake/pull/67)

