### PR TITLE
postgres: add socketDir option

### DIFF
--- a/nix/postgres/default.nix
+++ b/nix/postgres/default.nix
@@ -50,6 +50,12 @@ in
       description = "The DB data directory";
     };
 
+    socketDir = lib.mkOption {
+      type = lib.types.str;
+      default = config.dataDir;
+      description = "The DB socket directory";
+    };
+
     hbaConf =
       let
         hbaConfSubmodule = lib.types.submodule {
@@ -161,7 +167,7 @@ in
         default = {
           listen_addresses = config.listen_addresses;
           port = config.port;
-          unix_socket_directories = config.dataDir;
+          unix_socket_directories = config.socketDir;
           hba_file = "${config.hbaConfFile}";
         };
       };
@@ -181,7 +187,7 @@ in
         default = {
           listen_addresses = config.listen_addresses;
           port = config.port;
-          unix_socket_directories = lib.mkDefault config.dataDir;
+          unix_socket_directories = lib.mkDefault config.socketDir;
           hba_file = "${config.hbaConfFile}";
         };
         example = lib.literalExpression ''
@@ -292,12 +298,13 @@ in
                   text = ''
                     set -euo pipefail
                     PGDATA=$(readlink -f "${config.dataDir}")
+                    PGSOCKETDIR=$(readlink -f "${config.socketDir}")
                     export PGDATA
-                    postgres -k "$PGDATA"
+                    postgres -k "$PGSOCKETDIR"
                   '';
                 };
                 pg_isreadyArgs = [
-                  "-h $(readlink -f ${config.dataDir})"
+                  "-h $(readlink -f \"${config.socketDir}\")"
                   "-p ${toString config.port}"
                   "-d template1"
                 ] ++ (lib.optional (config.superuser != null) "-U ${config.superuser}");

--- a/nix/postgres/setup-script.nix
+++ b/nix/postgres/setup-script.nix
@@ -1,7 +1,6 @@
 { config, pkgs, lib }:
 let
   setupInitialSchema = dbName: schema: ''
-    ${lib.optionalString (schema != null) ''
     echo "Applying database schema on ${dbName}"
     if [ -f "${schema}" ]
     then
@@ -20,7 +19,6 @@ let
       echo "ERROR: Could not determine how to apply schema with ${schema}"
       exit 1
     fi
-    ''}
   '';
   setupInitialDatabases =
     if config.initialDatabases != [ ] then
@@ -37,7 +35,8 @@ let
           if [ 1 -ne "$dbAlreadyExists" ]; then
             echo "Creating database: ${database.name}"
             echo 'create database "${database.name}";' | psql -d postgres
-            ${lib.concatMapStrings (schema: setupInitialSchema (database.name) schema) database.schemas}
+            ${lib.optionalString (database.schemas != null)
+              (lib.concatMapStrings (schema: setupInitialSchema (database.name) schema) database.schemas)}
           fi
         '')
         config.initialDatabases)

--- a/nix/postgres/setup-script.nix
+++ b/nix/postgres/setup-script.nix
@@ -100,7 +100,7 @@ in
       echo
       echo "PostgreSQL is setting up the initial database."
       echo
-      PGHOST=$(mktemp -d "$(readlink -f ${config.dataDir})/pg-init-XXXXXX")
+      PGHOST=$(mktemp -d "$(readlink -f "${config.socketDir}")/pg-init-XXXXXX")
       export PGHOST
 
       function remove_tmp_pg_init_sock_dir() {


### PR DESCRIPTION
* Postgres: Fix a build failure when initialDatabase schema is null
* Postgres: Add a socketDir config option which defaults to config.dataDir and allows customization of socketDir for users who do not wish it fixed to dataDir
  * Also, sockets are limited to around [100 chars](https://linux.die.net/man/7/unix)
  * In the case that the default or desired dataDir absolute path exceeds this char limit, postgres will fail to start if it is also used for socketDir
  * In this case, dataDir can remain as desired and socketDir can be set separately to a shorter absolute path