### PR TITLE
[Postgres]: Fix `test` process not starting

### DIFF
--- a/example/flake.nix
+++ b/example/flake.nix
@@ -44,7 +44,7 @@
               port = 5433;
             };
             # Start `pg2-init` process after `pg1-init`
-            settings.processes.pg2.depends_on."pg1-init".condition = "process_completed_successfully";
+            settings.processes."pg2-init".depends_on."pg1-init".condition = "process_completed_successfully";
 
             settings.processes.pgweb =
               let

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -43,6 +43,8 @@
               listen_addresses = "127.0.0.1";
               port = 5433;
             };
+            # Start `pg2-init` process after `pg1-init`
+            settings.processes.pg2.depends_on."pg1-init".condition = "process_completed_successfully";
 
             settings.processes.pgweb =
               let

--- a/nix/postgres/default.nix
+++ b/nix/postgres/default.nix
@@ -230,24 +230,6 @@ in
       '';
     };
 
-    depends_on = lib.mkOption {
-      description = "Extra process dependency relationships for `${name}-init` process.";
-      type = types.nullOr (types.attrsOf (types.submodule {
-        options = {
-          condition = lib.mkOption {
-            type = types.enum [
-              "process_completed"
-              "process_completed_successfully"
-              "process_healthy"
-              "process_started"
-            ];
-            example = "process_healthy";
-          };
-        };
-      }));
-      default = null;
-    };
-
     initialScript = lib.mkOption {
       type = types.submodule ({ config, ... }: {
         options = {
@@ -298,7 +280,6 @@ in
               in
               {
                 command = setupScript;
-                depends_on = config.depends_on;
                 namespace = name;
               };
 

--- a/nix/postgres/postgres_test.nix
+++ b/nix/postgres/postgres_test.nix
@@ -17,6 +17,8 @@
       }
     ];
   };
+  # avoid both the processes trying to create `data` directory at the same time
+  settings.processes."pg2-init".depends_on."pg1-init".condition = "process_completed_successfully";
   settings.processes.test =
     let
       cfg = config.services.postgres."pg1";

--- a/nix/postgres/postgres_test.nix
+++ b/nix/postgres/postgres_test.nix
@@ -41,6 +41,9 @@
         '';
         name = "postgres-test";
       };
-      depends_on."pg1".condition = "process_healthy";
+      depends_on = {
+        "pg1".condition = "process_healthy";
+        "pg2".condition = "process_healthy";
+      };
     };
 }


### PR DESCRIPTION
On the first run, when `data` directory doesn’t exist, both the `init` processes (`pg1-init` and `pg2-init`) will try to create the `data` directory and one of them fails, leading to one of the server not starting. To solve this, `pg2-init` can depend on `pg1-init` completing.

Also `depends_on` option added to postgres [here](https://github.com/juspay/services-flake/pull/71), will not be needed because we can do it as demonstrated in `example/flake.nix` and `nix/postgres/postgres_test.nix` (check the diff). This keeps the definition of `depends_on` in one-place.

Resolves #74 

