### PR TITLE
ci: Don't upgrade Nix behind the scenes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v22
+      - run: nix --version
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:
           inputs-from: ./dev
-          packages: "nixpkgs"
-      - run: |
-          nix --version
-          nixci
+          packages: "nixpkgs#nixci"
+      - run: nixci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v22
       - run: nix --version
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      # Don't upgrade Nix until https://github.com/srid/nixci/issues/35 is fixed
+      - uses: DeterminateSystems/nix-installer-action@v0.13.1
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:
           inputs-from: ./dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,12 +12,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:
           inputs-from: ./dev
-          packages: "nixpkgs#nixci, nix"
+          packages: "nixpkgs"
       - run: |
           nix --version
           nixci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,5 +17,5 @@ jobs:
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:
           inputs-from: ./dev
-          packages: "nixpkgs#nixci"
-      - run: nixci $PWD
+          packages: "nixpkgs#nixci, nix"
+      - run: nixci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,6 @@ jobs:
         with:
           inputs-from: ./dev
           packages: "nixpkgs#nixci, nix"
-      - run: nixci
+      - run: |
+          nix --version
+          nixci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,4 @@ jobs:
         with:
           inputs-from: ./dev
           packages: "nixpkgs#nixci"
-      - run: nixci
+      - run: nixci $PWD

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
+      # Don't upgrade Nix until https://github.com/srid/nixci/issues/35 is fixed
       - uses: cachix/install-nix-action@v22
       - run: nix --version
-      # Don't upgrade Nix until https://github.com/srid/nixci/issues/35 is fixed
-      - uses: DeterminateSystems/nix-installer-action@v0.13.1
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:
           inputs-from: ./dev


### PR DESCRIPTION
The DetSys installer installs bleeding edge Nix, triggering https://github.com/srid/nixci/issues/35

Let's just use the "tried and true" https://github.com/cachix/install-nix-action where Nix is not upgraded behind the scenes over time (as long as we use Git tags).