### PR TITLE
postgres ensure socketDir mktemp init succeeds

### DIFF
--- a/nix/postgres/postgres_test.nix
+++ b/nix/postgres/postgres_test.nix
@@ -7,6 +7,7 @@
   };
   services.postgres."pg2" = {
     enable = true;
+    socketDir = "./test/new/socket/path";
     port = 5433;
     listen_addresses = "127.0.0.1";
     # INFO: pg1 creates $USER database while pg2 doesn't because `initialDatabases` is present
@@ -29,7 +30,7 @@
         text = ''
           echo 'SELECT version();' | psql -h 127.0.0.1
           echo 'SHOW hba_file;' | psql -h 127.0.0.1 | ${pkgs.gawk}/bin/awk 'NR==3' | grep '^ /nix/store'
-        
+
           # initialScript.before test
           echo "SELECT 1 FROM pg_roles WHERE rolname = 'bar';" | psql -h 127.0.0.1 | grep -q 1
 

--- a/nix/postgres/setup-script.nix
+++ b/nix/postgres/setup-script.nix
@@ -100,7 +100,7 @@ in
       echo
       echo "PostgreSQL is setting up the initial database."
       echo
-      PGHOST=$(mktemp -d "$(readlink -f "${config.socketDir}")/pg-init-XXXXXX")
+      PGHOST=$(mkdir -p "${config.socketDir}" && mktemp -d "$(readlink -f "${config.socketDir}")/pg-init-XXXXXX")
       export PGHOST
 
       function remove_tmp_pg_init_sock_dir() {


### PR DESCRIPTION
* Ensure postgres socketDir mktemp initialization succeeds when the socketDir path does not exist yet
  * See https://github.com/juspay/services-flake/pull/77#discussion_r1458072831
* Add a test for socketDir configured with a multi-level non-existing path