### PR TITLE
docs/clickhouse: Use heading anchors

### DIFF
--- a/doc/flake.lock
+++ b/doc/flake.lock
@@ -86,11 +86,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1705667811,
-        "narHash": "sha256-ZH/m5e4l4v2HRcv45trQKl92PRG6e1lpRJ4+U4zewL8=",
+        "lastModified": 1706115267,
+        "narHash": "sha256-Qper3WPSSmS7uQ/bDn6H/d5m8I1g4BJKrC13VMANtTs=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "bf573e7653d183baa0fa68e2e172333f585b7a25",
+        "rev": "a9048ab7fb2af092bd832ad5b587f83ab3a7844d",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     "heist-extra": {
       "flake": false,
       "locked": {
-        "lastModified": 1691619499,
-        "narHash": "sha256-4e8v5t4FM99pdcPhohP3dAeGtsFnirbfYGpbr2+qWxI=",
+        "lastModified": 1706086475,
+        "narHash": "sha256-scXMVFKSaS4Wi4y6I84oPKHaTmLECsvq8eLxGL0XH5o=",
         "owner": "srid",
         "repo": "heist-extra",
-        "rev": "54ff970f733dd45b5509d1c4c298927b6241041b",
+        "rev": "c6d8ef79b415fab276fb461d5860bbf2628e6e43",
         "type": "github"
       },
       "original": {

--- a/doc/services-flake/clickhouse.md
+++ b/doc/services-flake/clickhouse.md
@@ -11,8 +11,10 @@ ClickHouse is an open-source column-oriented DBMS (columnar database management 
 }
 ```
 
+{#tips}
 ## Tips & Tricks
 
+{#change-port}
 ### Change the HTTP default port
 
 Clickhouse has [HTTP Interface](https://clickhouse.com/docs/en/interfaces/http) that is enabled by default on port 8123. To change the default port, use the `extraConfig` option:


### PR DESCRIPTION
See https://emanote.srid.ca/guide/markdown#hanchor

This allows us to link to the individual sections using shorter links. It'd be good to follow this convention throughout other docs.