### PR TITLE
docs/clickhouse: add intro

### DIFF
--- a/doc/services-flake/clickhouse.md
+++ b/doc/services-flake/clickhouse.md
@@ -1,5 +1,7 @@
 # Clickhouse
 
+ClickHouse is an open-source column-oriented DBMS (columnar database management system) for online analytical processing (OLAP) that allows users to generate analytical reports using SQL queries in real-time.
+
 ## Getting Started
 
 ```nix


### PR DESCRIPTION
Emanote uses the first paragraph as page description, thus it is useful to write that paragraph reflecting the description of that page. Without this PR, link previews look like this:

<img width="444" alt="image" src="https://github.com/juspay/services-flake/assets/3998/8413020f-b1f4-4a90-8a1a-8cb644602b38">

^ which is not the correct description for the page.