### PR TITLE
Revert "ci: Don't upgrade Nix behind the scenes"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,5 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:
-          inputs-from: ./dev
-          packages: "nixpkgs#nixci"
-      - run: nix run github:srid/nixci/nix_rs_dir_fix
+          packages: "github:srid/nixci"
+      - run: nixci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.garnix.io?priority=40 https://cache.nixos.org/
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      # Don't upgrade Nix until https://github.com/srid/nixci/issues/35 is fixed
-      - uses: cachix/install-nix-action@v22
-      - run: nix --version
+      - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,4 @@ jobs:
         with:
           inputs-from: ./dev
           packages: "nixpkgs#nixci"
-      - run: nixci
+      - run: nix run github:srid/nixci/nix_rs_dir_fix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           extra-conf: |
             trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://cache.garnix.io?priority=40 https://cache.nixos.org/
+            substituters = https://cache.garnix.io?priority=41 https://cache.nixos.org/
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: yaxitech/nix-install-pkgs-action@v3
         with:


### PR DESCRIPTION
Reverts juspay/services-flake#79

To fix, https://github.com/srid/nixci/issues/35

Also, introduces Garnix cache to speed up fetching of nixci.