### PR TITLE
test: Fix impure access of parent paths

### DIFF
--- a/test/flake.nix
+++ b/test/flake.nix
@@ -37,15 +37,15 @@
               };
           in
           builtins.listToAttrs (builtins.map mkPackageFor [
-            ../nix/apache-kafka_test.nix
-            ../nix/clickhouse/clickhouse_test.nix
-            ../nix/elasticsearch_test.nix
-            ../nix/mysql_test.nix
-            ../nix/nginx_test.nix
-            ../nix/postgres/postgres_test.nix
-            ../nix/redis_test.nix
-            ../nix/redis-cluster_test.nix
-            ../nix/zookeeper_test.nix
+            "${inputs.services-flake}/nix/apache-kafka_test.nix"
+            "${inputs.services-flake}/nix/clickhouse/clickhouse_test.nix"
+            "${inputs.services-flake}/nix/elasticsearch_test.nix"
+            "${inputs.services-flake}/nix/mysql_test.nix"
+            "${inputs.services-flake}/nix/nginx_test.nix"
+            "${inputs.services-flake}/nix/postgres/postgres_test.nix"
+            "${inputs.services-flake}/nix/redis_test.nix"
+            "${inputs.services-flake}/nix/redis-cluster_test.nix"
+            "${inputs.services-flake}/nix/zookeeper_test.nix"
           ]);
       };
     };


### PR DESCRIPTION
This fixes,

```
error: access to absolute path '/nix/store/nix/apache-kafka_test.nix' is forbidden in pure eval mode (use '--impure' to override)
```

Seems to happen with newer Nix versions. See https://github.com/juspay/services-flake/pull/94#issuecomment-1937474878