### PR TITLE
just: test specific service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .direnv
+# created when `just test <service>` is used
+/result

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -27,6 +27,11 @@
           inputsFrom = [
             config.treefmt.build.devShell
           ];
+          shellHook = ''
+            echo
+            echo "🍎🍎 Run 'just <recipe>' to get started"
+            just
+          '';
         };
       };
     };

--- a/justfile
+++ b/justfile
@@ -9,6 +9,11 @@ ex:
 fmt:
     treefmt
 
-# Run native tests
-test:
+# Run native tests for all the services
+test-all:
     nix flake check test/ --override-input services-flake . -L
+
+# `nix flake check` doesn't support individual checks: https://github.com/NixOS/nix/issues/8881
+# Run native test for a specific service
+test service:
+    nix build ./test#checks.$(nix eval --impure --expr "builtins.currentSystem").{{service}} --override-input services-flake . -L


### PR DESCRIPTION
This is useful, as with the increasing number of services one might want to test only the service that they are making changes to.

**Note:** Here we are using `nix build` to test specific services as `nix flake check` doesn’t support running individual checks, see: https://github.com/NixOS/nix/issues/8881.

## Tested on

- [x] `x86_64-linux`
- [x] `aarch64-darwin`