### PR TITLE
add format check for services flake in dev/flake.nix

### DIFF
--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -88,7 +88,20 @@
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "nixpkgs": "nixpkgs",
+        "services-flake": "services-flake",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-lP05XSpUY4ILkuqAxcOGFlGmcK6r6d4Bv1zSXUQ+Ld0=",
+        "path": "../.",
+        "type": "path"
+      },
+      "original": {
+        "path": "../.",
+        "type": "path"
       }
     },
     "treefmt-nix": {

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -4,6 +4,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
     treefmt-nix.url = "github:numtide/treefmt-nix";
+    services-flake.url = "path:../.";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -14,6 +15,7 @@
       ];
       perSystem = { pkgs, lib, config, ... }: {
         treefmt = {
+          projectRoot = inputs.services-flake;
           projectRootFile = "flake.nix";
           programs = {
             nixpkgs-fmt.enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
         dir = "./test";
       };
       dev = {
+        inherit overrideInputs;
         dir = "./dev";
       };
       doc = {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -5,28 +5,19 @@
     systems.url = "github:nix-systems/default";
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
   };
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
       imports = [
         inputs.process-compose-flake.flakeModule
-        inputs.treefmt-nix.flakeModule
       ];
-      perSystem = { self', pkgs, system, lib, config, ... }: {
+      perSystem = { self', pkgs, system, lib, ... }: {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
           # Required for elastic search
           config.allowUnfree = true;
         };
-        treefmt = {
-          projectRootFile = "flake.nix";
-          programs = {
-            nixpkgs-fmt.enable = true;
-          };
-        };
-        checks.fmt-check = config.treefmt.build.check inputs.services-flake;
         process-compose =
           let
             mkPackageFor = mod:


### PR DESCRIPTION
adding `check` in `test/flake.nix` checks for the formatting across services flake

```
❯ nix run github:srid/nixci --option sandbox true .
```

```
treefmt-check> Initialized empty Git repository in /build/project/.git/
treefmt-check> Initialized empty Git repository in /build/project/.git/
treefmt-check> treefmt 0.6.0
treefmt-check> 0 files changed in 2ms (found 2, matched 1, cache misses 1)
treefmt-check> On branch main
treefmt-check> nothing to commit, working tree clean
treefmt-check> treefmt 0.6.0
treefmt-check> 0 files changed in 20ms (found 42, matched 26, cache misses 26)
treefmt-check> On branch main
treefmt-check> nothing to commit, working tree clean
```