### PR TITLE
clickhouse: use `lib.recursiveUpdate` to deep merge extraConfig

### DIFF
--- a/nix/clickhouse/default.nix
+++ b/nix/clickhouse/default.nix
@@ -27,7 +27,7 @@ in
       description = "The clickhouse data directory";
     };
 
-    defaultConfig = lib.mkOption {
+    defaultExtraConfig = lib.mkOption {
       type = yamlFormat.type;
       internal = true;
       readOnly = true;
@@ -97,7 +97,7 @@ in
         processes =
           let
             clickhouseConfig = yamlFormat.generate "clickhouse-config.yaml" (
-              lib.recursiveUpdate config.defaultConfig config.extraConfig
+              lib.recursiveUpdate config.defaultExtraConfig config.extraConfig
             );
           in
           {

--- a/nix/clickhouse/default.nix
+++ b/nix/clickhouse/default.nix
@@ -27,39 +27,15 @@ in
       description = "The clickhouse data directory";
     };
 
-    loggerLevel = lib.mkOption {
-      type = types.str;
-      default = "warning";
-      description = "Log level for clickhouse";
-    };
-
-    loggerConsole = lib.mkOption {
-      type = types.int;
-      default = 1;
-      description = "Log to console if not daemon mode and is tty";
-    };
-
-    defaultProfile = lib.mkOption {
-      type = types.str;
-      default = "default";
-      description = "Default profile of settings";
-    };
-
-    defaultDatabase = lib.mkOption {
-      type = types.str;
-      default = "default";
-      description = "Default database";
-    };
-
     defaultConfig = lib.mkOption {
       type = yamlFormat.type;
       internal = true;
       readOnly = true;
       default = {
-        logger.level = config.loggerLevel;
-        logger.console = config.loggerConsole;
-        default_profile = config.defaultProfile;
-        default_database = config.defaultDatabase;
+        logger.level = "warning";
+        logger.console = 1;
+        default_profile = "default";
+        default_database = "default";
         tcp_port = toString config.port;
         path = "${config.dataDir}/clickhouse";
         tmp_path = "${config.dataDir}/clickhouse/tmp";

--- a/nix/clickhouse/default.nix
+++ b/nix/clickhouse/default.nix
@@ -97,7 +97,7 @@ in
         processes =
           let
             clickhouseConfig = yamlFormat.generate "clickhouse-config.yaml" (
-              lib.recursiveUpdate config.extraConfig config.defaultConfig
+              lib.recursiveUpdate config.defaultConfig config.extraConfig
             );
           in
           {

--- a/nix/clickhouse/default.nix
+++ b/nix/clickhouse/default.nix
@@ -27,6 +27,52 @@ in
       description = "The clickhouse data directory";
     };
 
+    loggerLevel = lib.mkOption {
+      type = types.str;
+      default = "warning";
+      description = "Log level for clickhouse";
+    };
+
+    loggerConsole = lib.mkOption {
+      type = types.int;
+      default = 1;
+      description = "Log to console if not daemon mode and is tty";
+    };
+
+    defaultProfile = lib.mkOption {
+      type = types.str;
+      default = "default";
+      description = "Default profile of settings";
+    };
+
+    defaultDatabase = lib.mkOption {
+      type = types.str;
+      default = "default";
+      description = "Default database";
+    };
+
+    defaultConfig = lib.mkOption {
+      type = yamlFormat.type;
+      internal = true;
+      readOnly = true;
+      default = {
+        logger.level = config.loggerLevel;
+        logger.console = config.loggerConsole;
+        default_profile = config.defaultProfile;
+        default_database = config.defaultDatabase;
+        tcp_port = toString config.port;
+        path = "${config.dataDir}/clickhouse";
+        tmp_path = "${config.dataDir}/clickhouse/tmp";
+        user_files_path = "${config.dataDir}/clickhouse/user_files";
+        format_schema_path = "${config.dataDir}/clickhouse/format_schemas";
+        user_directories = {
+          users_xml = {
+            path = "${config.package}/etc/clickhouse-server/users.xml";
+          };
+        };
+      };
+    };
+
     extraConfig = lib.mkOption {
       type = yamlFormat.type;
       description = "Additional configuration to be appended to `clickhouse-config.yaml`.";
@@ -75,26 +121,7 @@ in
         processes =
           let
             clickhouseConfig = yamlFormat.generate "clickhouse-config.yaml" (
-              lib.recursiveUpdate
-                config.extraConfig
-                {
-                  logger = {
-                    level = "warning";
-                    console = 1;
-                  };
-                  tcp_port = "${toString config.port}";
-                  default_profile = "default";
-                  default_database = "default";
-                  path = "${config.dataDir}/clickhouse";
-                  tmp_path = "${config.dataDir}/clickhouse/tmp";
-                  user_files_path = "${config.dataDir}/clickhouse/user_files";
-                  format_schema_path = "${config.dataDir}/clickhouse/format_schemas";
-                  user_directories = {
-                    users_xml = {
-                      path = "${config.package}/etc/clickhouse-server/users.xml";
-                    };
-                  };
-                }
+              lib.recursiveUpdate config.extraConfig config.defaultConfig
             );
           in
           {

--- a/nix/clickhouse/default.nix
+++ b/nix/clickhouse/default.nix
@@ -75,24 +75,26 @@ in
         processes =
           let
             clickhouseConfig = yamlFormat.generate "clickhouse-config.yaml" (
-              {
-                logger = {
-                  level = "warning";
-                  console = 1;
-                };
-                tcp_port = "${toString config.port}";
-                default_profile = "default";
-                default_database = "default";
-                path = "${config.dataDir}/clickhouse";
-                tmp_path = "${config.dataDir}/clickhouse/tmp";
-                user_files_path = "${config.dataDir}/clickhouse/user_files";
-                format_schema_path = "${config.dataDir}/clickhouse/format_schemas";
-                user_directories = {
-                  users_xml = {
-                    path = "${config.package}/etc/clickhouse-server/users.xml";
+              lib.recursiveUpdate
+                config.extraConfig
+                {
+                  logger = {
+                    level = "warning";
+                    console = 1;
                   };
-                };
-              } // config.extraConfig
+                  tcp_port = "${toString config.port}";
+                  default_profile = "default";
+                  default_database = "default";
+                  path = "${config.dataDir}/clickhouse";
+                  tmp_path = "${config.dataDir}/clickhouse/tmp";
+                  user_files_path = "${config.dataDir}/clickhouse/user_files";
+                  format_schema_path = "${config.dataDir}/clickhouse/format_schemas";
+                  user_directories = {
+                    users_xml = {
+                      path = "${config.package}/etc/clickhouse-server/users.xml";
+                    };
+                  };
+                }
             );
           in
           {


### PR DESCRIPTION
previously, was shallow merge to append extra configs, which would have removed some configs. updated to use `lib.recursiveUpdate` to deep merge extraConfig.