### PR TITLE
Doc: add `contribuiting` doc to index; set order of `contributing` to -9

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,5 +1,5 @@
 ---
-order: 10
+order: -9
 ---
 
 # Contributing

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,6 +16,7 @@ It builds on top of the [process-compose-flake](https://community.flake.parts/pr
 See:
 - [[start]]#
 - [[services]]#
+- [[contributing]]#
 
 ## Demo
 


### PR DESCRIPTION
As of now contributing is no longer a child of services-flake (see https://community.flake.parts/services-flake):
<img width="353" alt="Screenshot 2024-02-27 at 4 39 23 PM" src="https://github.com/juspay/services-flake/assets/23645788/547328d3-81ae-41f0-8a81-7ed5f9484223">

After this change, contributing will appear after `Getting started` in the sidebar:
<img width="450" alt="Screenshot 2024-02-27 at 4 39 04 PM" src="https://github.com/juspay/services-flake/assets/23645788/ced23400-e582-4fe3-885e-d2dd47ccf81c">



