### PR TITLE
docs: Fix nix shell command

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -10,7 +10,7 @@ order: -9
 A Nix dev shell is available, providing `nixpkgs-fmt` and `just`. To enter the dev shell, run:
 
 ```sh
-nix develop .#dev
+nix develop ./dev
 ```
 
 An `.envrc` is also provided, so it is recommended to use `direnv` to automatically enter the dev shell when you `cd` into the project directory. See [this tutorial](https://nixos.asia/en/direnv).


### PR DESCRIPTION
Rebase this PR after #121 gets merged.

I used `docs:` in commit message, because:

<img width="940" alt="image" src="https://github.com/juspay/services-flake/assets/3998/861fa79b-0c45-4cb0-a275-0fd77dad7ff9">

https://www.conventionalcommits.org/en/v1.0.0/#summary