### PR TITLE
chore(docs): Use cfp module

### DIFF
--- a/doc/flake.lock
+++ b/doc/flake.lock
@@ -1,5 +1,40 @@
 {
   "nodes": {
+    "cfp": {
+      "inputs": {
+        "emanote": "emanote",
+        "flake-parts": [
+          "cfp",
+          "emanote",
+          "flake-parts"
+        ],
+        "haskell-flake": "haskell-flake_2",
+        "hercules-ci-effects": "hercules-ci-effects",
+        "mission-control": "mission-control",
+        "nixos-flake": "nixos-flake",
+        "nixpkgs": [
+          "cfp",
+          "emanote",
+          "nixpkgs"
+        ],
+        "process-compose-flake": "process-compose-flake",
+        "services-flake": "services-flake"
+      },
+      "locked": {
+        "lastModified": 1710101483,
+        "narHash": "sha256-J0Up78NX+/zWBtwspS8V+6eia3UtK1E9Gvpyu2Q4coQ=",
+        "owner": "flake-parts",
+        "repo": "community.flake.parts",
+        "rev": "f10e4a49dd2e7c37e1a15e3a5e5f108b07e0bd07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flake-parts",
+        "ref": "mod",
+        "repo": "community.flake.parts",
+        "type": "github"
+      }
+    },
     "commonmark-simple": {
       "flake": false,
       "locked": {
@@ -35,37 +70,41 @@
     "ema": {
       "inputs": {
         "flake-parts": [
+          "cfp",
           "emanote",
           "flake-parts"
         ],
         "flake-root": [
+          "cfp",
           "emanote",
           "flake-root"
         ],
         "haskell-flake": [
+          "cfp",
           "emanote",
           "haskell-flake"
         ],
         "nixpkgs": [
+          "cfp",
           "emanote",
           "nixpkgs"
         ],
         "treefmt-nix": [
+          "cfp",
           "emanote",
           "treefmt-nix"
         ]
       },
       "locked": {
-        "lastModified": 1702334080,
-        "narHash": "sha256-zrtzyLrSORxtocLMji5U9p4pDicMulOqgsuiB4LCu1o=",
+        "lastModified": 1707484760,
+        "narHash": "sha256-2wHRjoFJUpVnH7H/80bnaw8h3WELZqP9dM6DfjXWtAo=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "33f4cf31ace7e612e78ad25f5fc45089745ab644",
+        "rev": "e3539ddd27b72a6bb90c8614ae63c70ff3351936",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "no-ws",
         "repo": "ema",
         "type": "github"
       }
@@ -86,11 +125,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1706115267,
-        "narHash": "sha256-Qper3WPSSmS7uQ/bDn6H/d5m8I1g4BJKrC13VMANtTs=",
+        "lastModified": 1710093875,
+        "narHash": "sha256-B8n/7v80ybTg8OMi1JZ+IqOAHXzlmd4UA0VB+KjabII=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "a9048ab7fb2af092bd832ad5b587f83ab3a7844d",
+        "rev": "bb25c187f23863ca3bd1bfa991e6131d4e916484",
         "type": "github"
       },
       "original": {
@@ -133,6 +172,27 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "cfp",
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
     "flake-root": {
       "locked": {
         "lastModified": 1692742795,
@@ -150,11 +210,27 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1705067885,
-        "narHash": "sha256-al2JqNIkXfLiVreqSJWly64Z6YVNphWBh4m3IxGIdYI=",
+        "lastModified": 1709233214,
+        "narHash": "sha256-kraFY5MmY7yxsEtSF8qPrFVmA6MXkF+sJfo7EV1dcY8=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "8a526aaf98cde6af6b2d1d368e9acb460ee34547",
+        "rev": "3a8c1b58cff60886260156a20a3b3ad725bbf885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "haskell-flake_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710033782,
+        "narHash": "sha256-auDmdW8RFSmvymQLlsmD4Q5hn2BsXwp2v9b7LQKLMmE=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "938888c7ec66d265dda2dad9f4f4ffc9a5a30a78",
         "type": "github"
       },
       "original": {
@@ -176,6 +252,57 @@
       "original": {
         "owner": "srid",
         "repo": "heist-extra",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1708547820,
+        "narHash": "sha256-xU/KC1PWqq5zL9dQ9wYhcdgxAwdeF/dJCLPH3PNZEBg=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "0ca27bd58e4d5be3135a4bef66b582e57abe8f4a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "mission-control": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1707501043,
+        "narHash": "sha256-S3e8pfjXT335TuacspMyPbMnRX5c+qhvN4Jbm/R+3HM=",
+        "owner": "Platonic-Systems",
+        "repo": "mission-control",
+        "rev": "c275dd195776b1b9735790231d874a3c5a7ee779",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "mission-control",
+        "type": "github"
+      }
+    },
+    "nixos-flake": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708785992,
+        "narHash": "sha256-0gEsD/EpKrbLuLcYT9CXIVEY6ChmVvVTZJDAsqBXDhg=",
+        "owner": "srid",
+        "repo": "nixos-flake",
+        "rev": "50203d68b305abff2f29e555992eb55ddeffbcd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "nixos-flake",
         "type": "github"
       }
     },
@@ -213,17 +340,65 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1703637592,
+        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "process-compose-flake": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708624100,
+        "narHash": "sha256-zZPheCD9JGg2EtK4A9BsIdyl8447egOow4fjIfHFHRg=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "44d260ddba5a51570dee54d5cd4d8984edaf98c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "emanote": "emanote",
+        "cfp": "cfp",
         "flake-parts": [
-          "emanote",
+          "cfp",
           "flake-parts"
         ],
         "nixpkgs": [
-          "emanote",
+          "cfp",
           "nixpkgs"
         ]
+      }
+    },
+    "services-flake": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1709843710,
+        "narHash": "sha256-BP9Bp725C6Cp3k4YZfNbvPiRm6+3s5SCCPKOPyFpGZY=",
+        "owner": "juspay",
+        "repo": "services-flake",
+        "rev": "218fa6cc9a875c20def622e974fb4e0f391b3b6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "services-flake",
+        "type": "github"
       }
     },
     "systems": {
@@ -244,6 +419,7 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
+          "cfp",
           "emanote",
           "nixpkgs"
         ]
@@ -265,11 +441,11 @@
     "unionmount": {
       "flake": false,
       "locked": {
-        "lastModified": 1691619410,
-        "narHash": "sha256-V9/OcGu9cy4kV9jta12A6w5BEj8awSEVYrXPpg8YckQ=",
+        "lastModified": 1710078535,
+        "narHash": "sha256-gKBgBtuiRTD3/3EeY8aMgFzuaSEffJacBxsCB3ct1eg=",
         "owner": "srid",
         "repo": "unionmount",
-        "rev": "ed73b627f88c8f021f41ba4b518ba41beff9df42",
+        "rev": "41ae982fa118770bf4d3a3f2d48ac1ffb61c9f09",
         "type": "github"
       },
       "original": {

--- a/doc/flake.lock
+++ b/doc/flake.lock
@@ -21,11 +21,11 @@
         "services-flake": "services-flake"
       },
       "locked": {
-        "lastModified": 1710101483,
-        "narHash": "sha256-J0Up78NX+/zWBtwspS8V+6eia3UtK1E9Gvpyu2Q4coQ=",
+        "lastModified": 1710272905,
+        "narHash": "sha256-MU3cEeZVJX+wC5FTxdQXTOSds9OLScJv1b+hshrq0gM=",
         "owner": "flake-parts",
         "repo": "community.flake.parts",
-        "rev": "f10e4a49dd2e7c37e1a15e3a5e5f108b07e0bd07",
+        "rev": "52a0ad1d6fd3ff123efa7a58d96eb6c14359dc91",
         "type": "github"
       },
       "original": {

--- a/doc/flake.nix
+++ b/doc/flake.nix
@@ -1,36 +1,24 @@
 {
-  nixConfig = {
-    extra-substituters = "https://srid.cachix.org";
-    extra-trusted-public-keys = "srid.cachix.org-1:3clnql5gjbJNEvhA/WQp7nrZlBptwpXnUk6JAv8aB2M=";
-  };
-
   inputs = {
-    emanote.url = "github:srid/emanote";
-    nixpkgs.follows = "emanote/nixpkgs";
-    flake-parts.follows = "emanote/flake-parts";
+    cfp.url = "github:flake-parts/community.flake.parts/mod";
+    nixpkgs.follows = "cfp/nixpkgs";
+    flake-parts.follows = "cfp/flake-parts";
   };
 
-  outputs = inputs@{ self, flake-parts, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = nixpkgs.lib.systems.flakeExposed;
-      imports = [ inputs.emanote.flakeModule ];
-      perSystem = { self', pkgs, system, ... }: {
-        emanote = {
-          # By default, the 'emanote' flake input is used.
-          # package = inputs.emanote.packages.${system}.default;
-          sites."default" = {
-            layers = [ ./. ];
-            layersString = [ "." ];
-            port = 8181;
-            prettyUrls = true;
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
+      imports = [
+        inputs.cfp.flakeModules.default
+      ];
+      perSystem = {
+        flake-parts-docs = {
+          enable = true;
+          modules."nixos-flake" = {
+            path = ./.;
+            pathString = "./.";
           };
         };
-        devShells.default = pkgs.mkShell {
-          buildInputs = [
-            pkgs.nixpkgs-fmt
-          ];
-        };
-        formatter = pkgs.nixpkgs-fmt;
       };
     };
 }

--- a/justfile
+++ b/justfile
@@ -28,11 +28,11 @@ test service:
 
 # Run doc server with hot-reload
 doc:
-    nix run ./doc#docs
+    nix run ./doc
 
 # Build docs static website
 doc-static:
-    nix build ./doc#docs
+    nix build ./doc
 
 # Run service whose configuration is defined in `<service>_test.nix`
 run service:

--- a/justfile
+++ b/justfile
@@ -28,7 +28,11 @@ test service:
 
 # Run doc server with hot-reload
 doc:
-    cd ./doc && nix run
+    nix run ./doc#docs
+
+# Build docs static website
+doc-static:
+    nix build ./doc#docs
 
 # Run service whose configuration is defined in `<service>_test.nix`
 run service:


### PR DESCRIPTION
This enables us to preview the *whole* community.flake.parts (live server or static site) in the context of the local docs (./doc).

Uses https://github.com/flake-parts/community.flake.parts/pull/52