### PR TITLE
fix(mysql)!: look for `*.sql` files in the top-level schema directory

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,7 +7,7 @@ in
     ./apache-kafka.nix
     ./clickhouse
     ./elasticsearch.nix
-    ./mysql.nix
+    ./mysql
     ./nginx.nix
     ./postgres
     ./redis-cluster.nix

--- a/nix/mysql/default.nix
+++ b/nix/mysql/default.nix
@@ -216,7 +216,7 @@ in
 '';
 
             configureScript = pkgs.writeShellScriptBin "configure-mysql" ''
-              PATH="${lib.makeBinPath [config.package pkgs.coreutils]}:$PATH"
+              PATH="${lib.makeBinPath [config.package pkgs.coreutils pkgs.findutils]}:$PATH"
               set -euo pipefail
               ${envs} 
               ${lib.concatMapStrings (database: ''
@@ -237,7 +237,7 @@ in
                         cat ${database.schema}
                     elif [ -d "${database.schema}" ]
                     then
-                        cat ${database.schema}/mysql-databases/*.sql
+                        find ${database.schema} -type f -name '*.sql' | xargs cat
                     fi
                   ''}
                     ) | MYSQL_PWD="" ${config.package}/bin/mysql -u root -N

--- a/nix/mysql/test_schemas/bar.sql
+++ b/nix/mysql/test_schemas/bar.sql
@@ -1,0 +1,1 @@
+CREATE TABLE bar (id INT PRIMARY KEY);

--- a/nix/mysql/test_schemas/baz.md
+++ b/nix/mysql/test_schemas/baz.md
@@ -1,0 +1,1 @@
+CREATE TABLE baz (id INT PRIMARY KEY);

--- a/nix/mysql/test_schemas/foo.sql
+++ b/nix/mysql/test_schemas/foo.sql
@@ -1,0 +1,1 @@
+CREATE TABLE foo (id INT PRIMARY KEY);

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -36,7 +36,7 @@
             "${inputs.services-flake}/nix/apache-kafka_test.nix"
             "${inputs.services-flake}/nix/clickhouse/clickhouse_test.nix"
             "${inputs.services-flake}/nix/elasticsearch_test.nix"
-            "${inputs.services-flake}/nix/mysql_test.nix"
+            "${inputs.services-flake}/nix/mysql/mysql_test.nix"
             "${inputs.services-flake}/nix/nginx_test.nix"
             "${inputs.services-flake}/nix/postgres/postgres_test.nix"
             "${inputs.services-flake}/nix/redis_test.nix"


### PR DESCRIPTION
* mysql service would assume that all the `*.sql` files in the directory, provided by `initialDatabases [{ schema = <directory>; ... }]`, exists in a folder named [mysql-databases](https://github.com/juspay/services-flake/blob/291e7be83aa0f24b8e40fc61df4a895827788707/nix/mysql.nix#L239-L241), after this change it would just look for all the `*.sql` files in the top-level schema directory.
* add tests