### PR TITLE
refactor: writeShellScriptBin -> writeShellApplication

### DIFF
--- a/nix/apache-kafka.nix
+++ b/nix/apache-kafka.nix
@@ -161,14 +161,18 @@ with lib;
         processes = {
           "${name}" =
             let
-              startScript = pkgs.writeShellScriptBin "start-kafka" ''
-                ${config.jre}/bin/java \
-                  -cp "${config.package}/libs/*" \
-                  -Dlog4j.configuration=file:${config.configFiles.log4jProperties} \
-                  ${toString config.jvmOptions} \
-                  kafka.Kafka \
-                  ${config.configFiles.serverProperties}
-              '';
+              startScript = pkgs.writeShellApplication {
+                name = "start-kafka";
+                runtimeInputs = [ config.jre ];
+                text = ''
+                  java \
+                    -cp "${config.package}/libs/*" \
+                    -Dlog4j.configuration=file:${config.configFiles.log4jProperties} \
+                    ${toString config.jvmOptions} \
+                    kafka.Kafka \
+                    ${config.configFiles.serverProperties}
+                '';
+              };
             in
             {
               command = "${startScript}/bin/start-kafka";

--- a/nix/apache-kafka.nix
+++ b/nix/apache-kafka.nix
@@ -175,7 +175,7 @@ with lib;
               };
             in
             {
-              command = "${startScript}/bin/start-kafka";
+              command = startScript;
 
               readiness_probe = {
                 # TODO: need to find a better way to check if kafka is ready. Maybe use one of the scripts in bin?

--- a/nix/cassandra.nix
+++ b/nix/cassandra.nix
@@ -119,30 +119,34 @@ in
                 '';
               };
 
-              startScript = pkgs.writeShellScriptBin "start-cassandra" ''
-                set -euo pipefail
+              startScript = pkgs.writeShellApplication {
+                name = "start-cassandra";
+                runtimeInputs = [ pkgs.coreutils config.package ];
+                text = ''
+                  set -euo pipefail
 
-                DATA_DIR="$(readlink -m ${config.dataDir})"
-                if [[ ! -d "$DATA_DIR" ]]; then
-                  mkdir -p "$DATA_DIR"
-                fi
+                  DATA_DIR="$(readlink -m ${config.dataDir})"
+                  if [[ ! -d "$DATA_DIR" ]]; then
+                    mkdir -p "$DATA_DIR"
+                  fi
 
-                CASSANDRA_CONF="${cassandraConfig}"
-                export CASSANDRA_CONF
+                  CASSANDRA_CONF="${cassandraConfig}"
+                  export CASSANDRA_CONF
 
-                CASSANDRA_LOG_DIR="$DATA_DIR/log/"
-                mkdir -p "$CASSANDRA_LOG_DIR"
-                export CASSANDRA_LOG_DIR
+                  CASSANDRA_LOG_DIR="$DATA_DIR/log/"
+                  mkdir -p "$CASSANDRA_LOG_DIR"
+                  export CASSANDRA_LOG_DIR
 
-                CASSANDRA_HOME="${config.package}"
-                export CASSANDRA_HOME
+                  CASSANDRA_HOME="${config.package}"
+                  export CASSANDRA_HOME
 
-                CLASSPATH="${config.package}/lib"
-                export CLASSPATH
+                  CLASSPATH="${config.package}/lib"
+                  export CLASSPATH
 
-                export LOCAL_JMX="yes"
-                exec ${config.package}/bin/cassandra -f
-              '';
+                  export LOCAL_JMX="yes"
+                  cassandra -f
+                '';
+              };
             in
             {
               command = startScript;

--- a/nix/cassandra.nix
+++ b/nix/cassandra.nix
@@ -144,7 +144,7 @@ in
                   export CLASSPATH
 
                   export LOCAL_JMX="yes"
-                  cassandra -f
+                  exec cassandra -f
                 '';
               };
             in

--- a/nix/clickhouse/default.nix
+++ b/nix/clickhouse/default.nix
@@ -154,7 +154,7 @@ in
                 };
               in
               {
-                command = "${lib.getExe startScript}";
+                command = startScript;
 
                 readiness_probe = {
                   # FIXME: revert back to clickhouse-client readiness_probe once CI is moved out of github public runners

--- a/nix/elasticsearch.nix
+++ b/nix/elasticsearch.nix
@@ -182,7 +182,7 @@ in
                 chmod 0700 "${config.dataDir}/logs"
 
                 # Start it
-                elasticsearch ${toString config.extraCmdLineOptions}
+                exec elasticsearch ${toString config.extraCmdLineOptions}
               '';
             };
           in

--- a/nix/elasticsearch.nix
+++ b/nix/elasticsearch.nix
@@ -178,7 +178,7 @@ in
 
           in
           {
-            command = "${startScript}";
+            command = startScript;
 
             readiness_probe = {
               exec.command = "${pkgs.curl}/bin/curl -f -k http://${config.listenAddress}:${toString config.port}";

--- a/nix/mysql/default.nix
+++ b/nix/mysql/default.nix
@@ -278,7 +278,7 @@ in
           {
             "${name}" =
               {
-                command = "${startScript}/bin/start-mysql";
+                command = startScript;
 
                 readiness_probe = {
                   # Turns out using `--defaults-file` alone doesn't make the readiness_probe work unless `MYSQL_UNIX_PORT` is set.
@@ -296,7 +296,7 @@ in
                 availability.restart = "on_failure";
               };
             "${name}-configure" = {
-              command = "${configureScript}/bin/configure-mysql";
+              command = configureScript;
               namespace = name;
               depends_on."${name}".condition = "process_healthy";
             };

--- a/nix/mysql/default.nix
+++ b/nix/mysql/default.nix
@@ -217,7 +217,7 @@ in
                   ${lib.optionalString importTimeZones configureTimezones}
                 fi
                 ${envs}
-                mysqld ${mysqldOptions}
+                exec mysqld ${mysqldOptions}
               '';
             };
 

--- a/nix/mysql/default.nix
+++ b/nix/mysql/default.nix
@@ -169,16 +169,21 @@ in
             mysqlOptions = "--defaults-file=${configFile}";
             mysqldOptions = "${mysqlOptions} --datadir=${config.dataDir} --basedir=${config.package}";
             envs = ''
-              export MYSQL_HOME=$(${pkgs.coreutils}/bin/realpath ${config.dataDir})
-              export MYSQL_UNIX_PORT=$(${pkgs.coreutils}/bin/realpath ${config.dataDir + "/mysql.sock"})
-              export MYSQLX_UNIX_PORT=$(${pkgs.coreutils}/bin/realpath ${config.dataDir + "/mysqlx.sock"})
+              MYSQL_HOME=$(${pkgs.coreutils}/bin/realpath ${config.dataDir})
+              MYSQL_UNIX_PORT=$(${pkgs.coreutils}/bin/realpath ${config.dataDir + "/mysql.sock"})
+              MYSQLX_UNIX_PORT=$(${pkgs.coreutils}/bin/realpath ${config.dataDir + "/mysqlx.sock"})
+
+              export MYSQL_HOME
+              export MYSQL_UNIX_PORT
+              export MYSQLX_UNIX_PORT
+
               ${lib.optionalString (lib.hasAttrByPath [ "mysqld" "port" ] config.settings) "export MYSQL_TCP_PORT=${toString config.settings.mysqld.port}"}
             '';
 
             initDatabaseCmd =
               if isMariaDB
-              then "${config.package}/bin/mysql_install_db ${mysqldOptions} --auth-root-authentication-method=normal"
-              else "${config.package}/bin/mysqld ${mysqldOptions} --default-time-zone=SYSTEM --initialize-insecure";
+              then "mysql_install_db ${mysqldOptions} --auth-root-authentication-method=normal"
+              else "mysqld ${mysqldOptions} --default-time-zone=SYSTEM --initialize-insecure";
 
             importTimeZones =
               if (config.importTimeZones != null)
@@ -188,80 +193,87 @@ in
             configureTimezones = ''
               # Start a temp database with the default-time-zone to import tz data
               # and hide the temp database from the configureScript by setting a custom socket
-              nohup ${config.package}/bin/mysqld ${mysqldOptions} --socket="${config.dataDir}/config.sock" --skip-networking --default-time-zone=SYSTEM &
+              nohup mysqld ${mysqldOptions} --socket="${config.dataDir}/config.sock" --skip-networking --default-time-zone=SYSTEM &
 
-              while ! MYSQL_PWD="" ${config.package}/bin/mysqladmin --socket="${config.dataDir}/config.sock" ping -u root --silent; do
+              while ! MYSQL_PWD="" mysqladmin --socket="${config.dataDir}/config.sock" ping -u root --silent; do
                 sleep 1
               done
 
-              ${config.package}/bin/mysql_tzinfo_to_sql ${pkgs.tzdata}/share/zoneinfo/ | MYSQL_PWD="" ${config.package}/bin/mysql --socket="${config.dataDir}/config.sock" -u root mysql
+              mysql_tzinfo_to_sql ${pkgs.tzdata}/share/zoneinfo/ | MYSQL_PWD="" mysql --socket="${config.dataDir}/config.sock" -u root mysql
 
               # Shutdown the temp database
-              MYSQL_PWD="" ${config.package}/bin/mysqladmin --socket="${config.dataDir}/config.sock" shutdown -u root
+              MYSQL_PWD="" mysqladmin --socket="${config.dataDir}/config.sock" shutdown -u root
             '';
 
-            startScript = pkgs.writeShellScriptBin "start-mysql" ''
-              set -euo pipefail
+            startScript = pkgs.writeShellApplication {
+              name = "start-mysql";
+              runtimeInputs = [ config.package pkgs.coreutils ];
+              text = ''
+                set -euo pipefail
 
-              if [[ ! -d ${config.dataDir} || ! -f ${config.dataDir}/ibdata1 ]]; then
-                mkdir -p ${config.dataDir}
-                ${initDatabaseCmd}
-                ${lib.optionalString importTimeZones configureTimezones}
-              fi
-              ${envs}
-              exec ${config.package}/bin/mysqld ${mysqldOptions}
-            '';
+                if [[ ! -d ${config.dataDir} || ! -f ${config.dataDir}/ibdata1 ]]; then
+                  mkdir -p ${config.dataDir}
+                  ${initDatabaseCmd}
+                  ${lib.optionalString importTimeZones configureTimezones}
+                fi
+                ${envs}
+                mysqld ${mysqldOptions}
+              '';
+            };
 
-            runInitialScript = lib.optionalString (config.initialScript != null) ''echo ${lib.escapeShellArg config.initialScript} | MYSQL_PWD="" ${config.package}/bin/mysql -u root -N
+            runInitialScript = lib.optionalString (config.initialScript != null) ''echo ${lib.escapeShellArg config.initialScript} | MYSQL_PWD="" mysql -u root -N
 '';
 
-            configureScript = pkgs.writeShellScriptBin "configure-mysql" ''
-              PATH="${lib.makeBinPath [config.package pkgs.coreutils pkgs.findutils]}:$PATH"
-              set -euo pipefail
-              ${envs} 
-              ${lib.concatMapStrings (database: ''
-                  # Create initial databases
-                  exists="$(
-                    MYSQL_PWD="" ${config.package}/bin/mysql -u root -sB information_schema \
-                      <<< 'select count(*) from schemata where schema_name = "${database.name}"'
-                  )"
-                  if [[ "$exists" -eq 0 ]]; then
-                    echo "Creating initial database: ${database.name}"
-                    ( echo 'create database `${database.name}`;'
-                      ${lib.optionalString (database.schema != null) ''
-                    echo 'use `${database.name}`;'
-                    # TODO: this silently falls through if database.schema does not exist,
-                    # we should catch this somehow and exit, but can't do it here because we're in a subshell.
-                    if [ -f "${database.schema}" ]
-                    then
-                        cat ${database.schema}
-                    elif [ -d "${database.schema}" ]
-                    then
-                        find ${database.schema} -type f -name '*.sql' | xargs cat
+            configureScript = pkgs.writeShellApplication {
+              name = "configure-mysql";
+              runtimeInputs = with pkgs; [ config.package coreutils findutils ];
+              text = ''
+                set -euo pipefail
+                ${envs}
+                ${lib.concatMapStrings (database: ''
+                    # Create initial databases
+                    exists="$(
+                      MYSQL_PWD="" mysql -u root -sB information_schema \
+                        <<< 'select count(*) from schemata where schema_name = "${database.name}"'
+                    )"
+                    if [[ "$exists" -eq 0 ]]; then
+                      echo "Creating initial database: ${database.name}"
+                      ( echo "create database ${database.name};"
+                        ${lib.optionalString (database.schema != null) ''
+                      echo "use ${database.name};"
+                      # TODO: this silently falls through if database.schema does not exist,
+                      # we should catch this somehow and exit, but can't do it here because we're in a subshell.
+                      if [ -f "${database.schema}" ]
+                      then
+                          cat ${database.schema}
+                      elif [ -d "${database.schema}" ]
+                      then
+                          # -print0/-0 is used because of: https://www.shellcheck.net/wiki/SC2038
+                          find ${database.schema} -type f -name '*.sql' -print0 | xargs -0 cat
+                      fi
+                    ''}
+                      ) | MYSQL_PWD="" mysql -u root -N
+                    else
+                      echo "Database ${database.name} exists, skipping creation."
                     fi
-                  ''}
-                    ) | MYSQL_PWD="" ${config.package}/bin/mysql -u root -N
-                  else
-                    echo "Database ${database.name} exists, skipping creation."
-                  fi
-                '')
-                config.initialDatabases}
+                  '')
+                  config.initialDatabases}
 
-              ${lib.concatMapStrings (user: ''
-                  echo "Adding user: ${user.name}"
-                  ${lib.optionalString (user.password != null) "password='${user.password}'"}
-                  ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${lib.optionalString (user.password != null) "IDENTIFIED BY '$password'"};"
-                    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (database: permission: ''
-                      echo 'GRANT ${permission} ON ${database} TO `${user.name}`@`localhost`;'
-                    '')
-                    user.ensurePermissions)}
-                  ) | MYSQL_PWD="" ${config.package}/bin/mysql -u root -N
-                '')
-                config.ensureUsers}
-    
-              ${runInitialScript}
-            '';
+                ${lib.concatMapStrings (user: ''
+                    echo "Adding user: ${user.name}"
+                    ${lib.optionalString (user.password != null) "password='${user.password}'"}
+                    ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${lib.optionalString (user.password != null) "IDENTIFIED BY '$password'"};"
+                      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (database: permission: ''
+                        echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
+                      '')
+                      user.ensurePermissions)}
+                    ) | MYSQL_PWD="" mysql -u root -N
+                  '')
+                  config.ensureUsers}
 
+                ${runInitialScript}
+              '';
+            };
           in
           {
             "${name}" =

--- a/nix/nginx.nix
+++ b/nix/nginx.nix
@@ -106,7 +106,7 @@ in
         in
         {
           processes."${name}" = {
-            command = "${startScript}/bin/start-nginx";
+            command = startScript;
             readiness_probe = {
               # FIXME need a better health check
               exec.command = "[ -e ${config.dataDir}/nginx/nginx.pid ]";

--- a/nix/nginx.nix
+++ b/nix/nginx.nix
@@ -92,13 +92,17 @@ in
       readOnly = true;
       default =
         let
-          startScript = pkgs.writeShellScriptBin "start-nginx" ''
-            set -euo pipefail
-            if [[ ! -d "${config.dataDir}" ]]; then
-              mkdir -p "${config.dataDir}"
-            fi
-            ${config.package}/bin/nginx -p $(pwd) -c ${config.configFile} -e /dev/stderr
-          '';
+          startScript = pkgs.writeShellApplication {
+            name = "start-nginx";
+            runtimeInputs = [ pkgs.coreutils config.package ];
+            text = ''
+              set -euo pipefail
+              if [[ ! -d "${config.dataDir}" ]]; then
+                mkdir -p "${config.dataDir}"
+              fi
+              nginx -p "$(pwd)" -c ${config.configFile} -e /dev/stderr
+            '';
+          };
         in
         {
           processes."${name}" = {

--- a/nix/prometheus.nix
+++ b/nix/prometheus.nix
@@ -84,7 +84,7 @@ in
               };
             in
             {
-              command = "${startScript}/bin/start-prometheus";
+              command = startScript;
               readiness_probe = {
                 http_get = {
                   host = config.listenAddress;

--- a/nix/redis-cluster.nix
+++ b/nix/redis-cluster.nix
@@ -90,17 +90,21 @@ in
                 ${cfg.extraConfig}
               '';
 
-              startScript = pkgs.writeShellScriptBin "start-redis" ''
-                set -euo pipefail
+              startScript = pkgs.writeShellApplication {
+                name = "start-redis";
+                runtimeInputs = [ pkgs.coreutils config.package ];
+                text = ''
+                  set -euo pipefail
 
-                export REDISDATA=${config.dataDir}
+                  export REDISDATA=${config.dataDir}
 
-                if [[ ! -d "$REDISDATA" ]]; then
-                  mkdir -p "$REDISDATA"
-                fi
+                  if [[ ! -d "$REDISDATA" ]]; then
+                    mkdir -p "$REDISDATA"
+                  fi
 
-                exec ${config.package}/bin/redis-server ${redisConfig} --dir "$REDISDATA"
-              '';
+                  redis-server ${redisConfig} --dir "$REDISDATA"
+                '';
+              };
             in
             lib.nameValuePair "${name}-${nodeName}" {
               command = "${startScript}/bin/start-redis";

--- a/nix/redis-cluster.nix
+++ b/nix/redis-cluster.nix
@@ -102,7 +102,7 @@ in
                     mkdir -p "$REDISDATA"
                   fi
 
-                  redis-server ${redisConfig} --dir "$REDISDATA"
+                  exec redis-server ${redisConfig} --dir "$REDISDATA"
                 '';
               };
             in

--- a/nix/redis-cluster.nix
+++ b/nix/redis-cluster.nix
@@ -107,7 +107,7 @@ in
               };
             in
             lib.nameValuePair "${name}-${nodeName}" {
-              command = "${startScript}/bin/start-redis";
+              command = startScript;
               shutdown.command = "${config.package}/bin/redis-cli -p ${port} shutdown nosave";
 
               readiness_probe = {

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -72,7 +72,7 @@ in
               };
             in
             {
-              command = "${startScript}/bin/start-redis";
+              command = startScript;
 
               readiness_probe = {
                 exec.command = "${config.package}/bin/redis-cli -p ${toString config.port} ping";

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -67,7 +67,7 @@ in
                     mkdir -p "$REDISDATA"
                   fi
 
-                  redis-server ${redisConfig} --dir "$REDISDATA"
+                  exec redis-server ${redisConfig} --dir "$REDISDATA"
                 '';
               };
             in

--- a/nix/redis.nix
+++ b/nix/redis.nix
@@ -55,17 +55,21 @@ in
                 ${config.extraConfig}
               '';
 
-              startScript = pkgs.writeShellScriptBin "start-redis" ''
-                set -euo pipefail
+              startScript = pkgs.writeShellApplication {
+                name = "start-redis";
+                runtimeInputs = [ pkgs.coreutils config.package ];
+                text = ''
+                  set -euo pipefail
 
-                export REDISDATA=${config.dataDir}
+                  export REDISDATA=${config.dataDir}
 
-                if [[ ! -d "$REDISDATA" ]]; then
-                  mkdir -p "$REDISDATA"
-                fi
+                  if [[ ! -d "$REDISDATA" ]]; then
+                    mkdir -p "$REDISDATA"
+                  fi
 
-                exec ${config.package}/bin/redis-server ${redisConfig} --dir "$REDISDATA"
-              '';
+                  redis-server ${redisConfig} --dir "$REDISDATA"
+                '';
+              };
             in
             {
               command = "${startScript}/bin/start-redis";

--- a/nix/zookeeper.nix
+++ b/nix/zookeeper.nix
@@ -123,15 +123,19 @@ with lib;
                 ];
               };
 
-              startScript = pkgs.writeShellScriptBin "start-zookeeper" ''
-                ${config.jre}/bin/java \
-                  -cp "${config.package}/lib/*:${configDir}" \
-                  ${escapeShellArgs config.extraCmdLineOptions} \
-                  -Dzookeeper.datadir.autocreate=true \
-                  ${optionalString config.preferIPv4 "-Djava.net.preferIPv4Stack=true"} \
-                  org.apache.zookeeper.server.quorum.QuorumPeerMain \
-                  ${configDir}/zoo.cfg
-              '';
+              startScript = pkgs.writeShellApplication {
+                name = "start-zookeeper";
+                runtimeInputs = [ config.jre ];
+                text = ''
+                  java \
+                    -cp "${config.package}/lib/*:${configDir}" \
+                    ${escapeShellArgs config.extraCmdLineOptions} \
+                    -Dzookeeper.datadir.autocreate=true \
+                    ${optionalString config.preferIPv4 "-Djava.net.preferIPv4Stack=true"} \
+                    org.apache.zookeeper.server.quorum.QuorumPeerMain \
+                    ${configDir}/zoo.cfg
+                '';
+              };
             in
             {
               command = "${startScript}/bin/start-zookeeper";

--- a/nix/zookeeper.nix
+++ b/nix/zookeeper.nix
@@ -138,7 +138,7 @@ with lib;
               };
             in
             {
-              command = "${startScript}/bin/start-zookeeper";
+              command = startScript;
 
               readiness_probe = {
                 exec.command = "echo stat | ${pkgs.netcat.nc}/bin/nc localhost ${toString config.port}";


### PR DESCRIPTION
Provides us with following benefits:
- use `runtimeInputs` instead of manually exporting `PATH`
- get shellcheck by default