### PR TITLE
fix(postgres): empty `socketDir` by default

### DIFF
--- a/doc/postgresql.md
+++ b/doc/postgresql.md
@@ -20,6 +20,9 @@
 {#socket-path}
 ### Unix-domain socket path is too long
 
+> [!warning]
+> Only relevant if `socketDir` is set. If not, postgres uses TCP/IP by default.
+
 We already talk about this in the [data directory guide](datadir.md#socket-path). In case of postgres, you can set `socketDir` while keeping the `dataDir` unchanged.
 
 >[!note]

--- a/nix/postgres/default.nix
+++ b/nix/postgres/default.nix
@@ -54,6 +54,10 @@ in
       type = lib.types.str;
       default = "";
       description = "The DB socket directory";
+      defaultText = ''
+        An empty value specifies not listening on any Unix-domain sockets, in which case only TCP/IP sockets can be used to connect to the server.
+        See: https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-UNIX-SOCKET-DIRECTORIES
+      '';
     };
 
     # Based on: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS


### PR DESCRIPTION
resolves #139 

the solution is implemented based on https://github.com/juspay/services-flake/issues/139#issuecomment-1998114104

An empty `socketDir` would mean that by default the `postgres` service will use TCP/IP instead of Unix-domain sockets.