### PR TITLE
fix(test): grafana on darwin is no longer broken in upstream

### DIFF
--- a/test/flake.lock
+++ b/test/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711655175,
-        "narHash": "sha256-1xiaYhC3ul4y+i3eicYxeERk8ZkrNjLkrFSb/UW36Zw=",
+        "lastModified": 1712090461,
+        "narHash": "sha256-PAfFp+YEKpkzwz6ruXQMvTa1puO4ySSu2G4Sp/jkCc8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c81edb4b97a51c5bbc54c191763ac71a6517ee",
+        "rev": "e976fa8f49c35cf28496301a1ef2aa23ad576b56",
         "type": "github"
       },
       "original": {

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709294055,
-        "narHash": "sha256-7EECkQYoNKJZOf2+miJdrMpxpvsn/qZFwIhUI3fQpLs=",
+        "lastModified": 1711655175,
+        "narHash": "sha256-1xiaYhC3ul4y+i3eicYxeERk8ZkrNjLkrFSb/UW36Zw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec869190b56a1b4677d24a8bdbcfe80ccea2ece6",
+        "rev": "64c81edb4b97a51c5bbc54c191763ac71a6517ee",
         "type": "github"
       },
       "original": {

--- a/test/nix/pkgs.nix
+++ b/test/nix/pkgs.nix
@@ -11,10 +11,6 @@
       overlays = [
         (self: super: lib.optionalAttrs super.stdenv.isDarwin {
 
-          # grafana is broken on aarch64-darwin, but works on older nixpkgs:
-          # https://github.com/NixOS/nixpkgs/issues/273998
-          grafana = (builtins.getFlake "github:nixos/nixpkgs/b604023e0a5549b65da3040a07d2beb29ac9fc63").legacyPackages.${system}.grafana;
-
           # Disable tests, because they are failing on darwin:
           # https://github.com/NixOS/nixpkgs/issues/281214
           pgadmin4 = super.pgadmin4.overrideAttrs (_: {


### PR DESCRIPTION
fixed here: https://github.com/NixOS/nixpkgs/pull/297968

Also, hydra-checks pass on all four platforms:

```sh
shivaraj in 🌐 nixos in ~
❯ nix run github:nix-community/hydra-check -- grafana --arch aarch64-darwin
Build Status for grafana.aarch64-darwin on jobset nixpkgs/trunk
✔ grafana-10.4.1 from 2024-03-27 - https://hydra.nixos.org/build/254421303

shivaraj in 🌐 nixos in ~ took 45s
❯ nix run github:nix-community/hydra-check -- grafana --arch x86_64-darwin
Build Status for grafana.x86_64-darwin on jobset nixpkgs/trunk
✔ grafana-10.4.1 from 2024-03-27 - https://hydra.nixos.org/build/254422747

shivaraj in 🌐 nixos in ~
❯ nix run github:nix-community/hydra-check -- grafana --arch x86_64-linux
Build Status for nixpkgs.grafana.x86_64-linux on jobset nixos/trunk-combined
✔ grafana-10.4.0 from 2024-03-27 - https://hydra.nixos.org/build/254385494

shivaraj in 🌐 nixos in ~
❯ nix run github:nix-community/hydra-check -- grafana --arch aarch64-linux
Build Status for nixpkgs.grafana.aarch64-linux on jobset nixos/trunk-combined
✔ grafana-10.4.0 from 2024-03-27 - https://hydra.nixos.org/build/254392946
```