### PR TITLE
Fix pgadmin scripts on MacOS

### DIFF
--- a/nix/pgadmin.nix
+++ b/nix/pgadmin.nix
@@ -103,7 +103,11 @@ in
               let
                 setupScript = pkgs.writeShellApplication {
                   name = "setup-pgadmin";
-                  runtimeInputs = [ config.package ];
+                  runtimeInputs =
+                    [ config.package ] ++
+                    (lib.lists.optionals pkgs.stdenv.isDarwin [
+                      pkgs.coreutils
+                    ]);
                   text = ''
                     export PYTHONPATH="${pgadminConfig}"
                     PGADMIN_DATADIR="$(readlink -m ${config.dataDir})"
@@ -132,7 +136,11 @@ in
               let
                 startScript = pkgs.writeShellApplication {
                   name = "start-pgadmin";
-                  runtimeInputs = [ config.package ];
+                  runtimeInputs =
+                    [ config.package ] ++
+                    (lib.lists.optionals pkgs.stdenv.isDarwin [
+                      pkgs.coreutils
+                    ]);
                   text = ''
                     export PYTHONPATH="${pgadminConfig}"
                     PGADMIN_DATADIR="$(readlink -m ${config.dataDir})"


### PR DESCRIPTION
Hey, just a little fix for mac:
`readlink -m` is invalid on mac. Added coreutils as a runtime input for darwin.

Other scripts in the repo have a similar issue (using the -m flag for e.g.) but I am not using them atm so cannot QA very well.