### PR TITLE
fix(postgres): fix pg_isready issue with empty listen_addresses

### DIFF
--- a/nix/postgres/default.nix
+++ b/nix/postgres/default.nix
@@ -323,7 +323,7 @@ in
                   '';
                 };
                 pg_isreadyArgs = [
-                  "-h ${config.listen_addresses}"
+                  (if config.socketDir != "" then "-h $(readlink -f \"${config.socketDir}\")" else "-h ${config.listen_addresses}")
                   "-p ${toString config.port}"
                   "-d template1"
                 ] ++ (lib.optional (config.superuser != null) "-U ${config.superuser}");


### PR DESCRIPTION
This PR resolves the issue where `pg_isready` would fail when `socketDir` is set and `listen_addresses` is empty. `pg_isready` is now modified to use `socketDir` when it is available.