### PR TITLE
fix: use absolute socket path in configureTimezones. this fixes #169

### DIFF
--- a/nix/mysql/default.nix
+++ b/nix/mysql/default.nix
@@ -193,16 +193,15 @@ in
             configureTimezones = ''
               # Start a temp database with the default-time-zone to import tz data
               # and hide the temp database from the configureScript by setting a custom socket
-              nohup mysqld ${mysqldOptions} --socket="${config.dataDir}/config.sock" --skip-networking --default-time-zone=SYSTEM &
+              CONFIG_SOCKET="$(${pkgs.coreutils}/bin/realpath ${config.dataDir + "/config.sock"})"
+              nohup mysqld ${mysqldOptions} --socket="$CONFIG_SOCKET" --skip-networking --default-time-zone=SYSTEM &
 
-              while ! MYSQL_PWD="" mysqladmin --socket="${config.dataDir}/config.sock" ping -u root --silent; do
+              while ! MYSQL_PWD="" mysqladmin --socket="$CONFIG_SOCKET" ping -u root --silent; do
                 sleep 1
               done
-
-              mysql_tzinfo_to_sql ${pkgs.tzdata}/share/zoneinfo/ | MYSQL_PWD="" mysql --socket="${config.dataDir}/config.sock" -u root mysql
-
+              mysql_tzinfo_to_sql ${pkgs.tzdata}/share/zoneinfo | MYSQL_PWD="" mysql --socket="$CONFIG_SOCKET" -u root mysql
               # Shutdown the temp database
-              MYSQL_PWD="" mysqladmin --socket="${config.dataDir}/config.sock" shutdown -u root
+              MYSQL_PWD="" mysqladmin --socket="$CONFIG_SOCKET" shutdown -u root
             '';
 
             startScript = pkgs.writeShellApplication {


### PR DESCRIPTION
The change fixes #169. Tested locally. To reproduce the original issue just try to spin up a local mysql service using `nixpkgs-old.legacyPackages.mysql57` package while `mysqld.default-time-zone` or `importTimeZones` is set.