### PR TITLE
feat(grafana): add providers configuration

### DIFF
--- a/nix/grafana.nix
+++ b/nix/grafana.nix
@@ -51,7 +51,11 @@ in
 
     datasources = lib.mkOption {
       type = types.listOf yamlFormat.type;
-      description = "List of data sources to configure.";
+      description = ''
+        List of data sources to configure.
+
+        See https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources for the schema.
+      '';
       default = [ ];
       example = ''
         [
@@ -71,6 +75,28 @@ in
       example = ''
         [
           { name = "Tempo"; }
+        ]
+      '';
+    };
+
+    providers = lib.mkOption {
+      type = types.listOf yamlFormat.type;
+      description = ''
+        List of dashboard providers to configure.
+
+        See https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards for the schema.
+      '';
+      default = [ ];
+      example = ''
+        [
+          {
+            name = "Databases";
+            type = "file";
+            options = {
+              path = ./dashboards;
+              foldersFromFilesStructure = true;
+            };
+          }
         ]
       '';
     };
@@ -97,10 +123,15 @@ in
                 deleteDatasources = config.deleteDatasources;
                 datasources = config.datasources;
               };
+              providersYaml = yamlFormat.generate "providers.yaml" {
+                apiVersion = 1;
+                providers = config.providers;
+              };
               buildCommand = ''
                 mkdir -p $out
                 mkdir -p $out/alerting
                 mkdir -p $out/dashboards
+                ln -s "$providersYaml" "$out/dashboards/providers.yaml"
                 mkdir -p $out/datasources
                 ln -s "$datasourcesYaml" "$out/datasources/datasources.yaml"
                 mkdir -p $out/notifiers

--- a/nix/grafana_test.nix
+++ b/nix/grafana_test.nix
@@ -81,7 +81,7 @@ in {
             curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/org/users | grep admin\@localhost
             # The dashboard provisioner was used to create a dashboard.
             curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} -i
-            curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} | grep '"title":${dashboardTitle}'
+            curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} | grep '"title”:"${dashboardTitle}"'
           '';
         name = "grafana-test";
       };

--- a/nix/grafana_test.nix
+++ b/nix/grafana_test.nix
@@ -43,7 +43,8 @@ let
       "weekStart": ""
     }
   '';
-in {
+in
+{
   services.grafana."gf1" =
     {
       enable = true;
@@ -81,7 +82,7 @@ in {
             curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/org/users | grep admin\@localhost
             # The dashboard provisioner was used to create a dashboard.
             curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} -i
-            curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} | grep '"title”:"${dashboardTitle}"'
+            curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} | grep '"title":"${dashboardTitle}"'
           '';
         name = "grafana-test";
       };

--- a/nix/grafana_test.nix
+++ b/nix/grafana_test.nix
@@ -1,4 +1,49 @@
-{ pkgs, config, ... }: {
+{ pkgs, config, ... }:
+let
+  dashboardUid = "adnyzrfa5cqv4c";
+  dashboardTitle = "Test dashboard";
+  dashboards = pkgs.writeTextDir "dashboards/test_dashboard.json" ''
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 3,
+      "links": [],
+      "panels": [],
+      "schemaVersion": 39,
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "${dashboardTitle}",
+      "uid": "${dashboardUid}",
+      "version": 1,
+      "weekStart": ""
+    }
+  '';
+in {
   services.grafana."gf1" =
     {
       enable = true;
@@ -7,6 +52,15 @@
         security.admin_user = "patato";
         security.admin_password = "potato";
       };
+      providers = [
+        {
+          name = "Test dashboard provider";
+          type = "file";
+          options = {
+            path = "${dashboards}/dashboards";
+          };
+        }
+      ];
     };
 
   settings.processes.test =
@@ -22,8 +76,12 @@
             ADMIN=${cfg.extraConf.security.admin_user}
             PASSWORD=${cfg.extraConf.security.admin_password}
             ROOT_URL="${cfg.protocol}://${cfg.domain}:${builtins.toString cfg.http_port}";
+            # The admin user can authenticate against the running service.
             curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/org/users -i
             curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/org/users | grep admin\@localhost
+            # The dashboard provisioner was used to create a dashboard.
+            curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} -i
+            curl -sSfN -u $ADMIN:$PASSWORD $ROOT_URL/api/dashboards/uid/${dashboardUid} | grep '"title":${dashboardTitle}'
           '';
         name = "grafana-test";
       };


### PR DESCRIPTION
Addresses juspay/services-flake#210.

I've tested this by hand with configuration:

```nix
services.grafana."grafana" = {
  enable = true;
  providers = [
    {
      name = "Databases";
      type = "file";
      options = {
        path = ./dashboards;
        foldersFromFilesStructure = true;
      };
    }
  ];
};
```

I haven't looked into it, but it might be possible to extend the existing Grafana test to check that a folder of dashboards is loaded.