### PR TITLE
`examples/llm`: Reintroduce `dataDir` and `models`, with explanation on `README.md`

### DIFF
--- a/example/llm/README.md
+++ b/example/llm/README.md
@@ -1,0 +1,6 @@
+# Running local LLM using ollama and open-webui
+
+While `services-flake` is generally used for running services in a *development* project, typically under a source code checkout, you can also write flakes to derive an end-user app which runs a group of services. 
+
+`example/llm` runs two processes ollama and open-webui, while storing the ollama data under `$HOME/.services-flake/ollama`. You can change this path in `flake.nix`.
+

--- a/example/llm/README.md
+++ b/example/llm/README.md
@@ -4,3 +4,4 @@ While `services-flake` is generally used for running services in a *development*
 
 `example/llm` runs two processes ollama and open-webui, while storing the ollama data under `$HOME/.services-flake/ollama`. You can change this path in `flake.nix`.
 
+By default, a single model (`llama2-uncensored`) is downloaded. You can modify this in `flake.nix` as well.

--- a/example/llm/flake.nix
+++ b/example/llm/flake.nix
@@ -25,7 +25,7 @@
             # directory can lead to a lot of duplication. Change here to a
             # directory where the Ollama models can be stored and shared across
             # projects.
-            # dataDir = "$HOME/.services-flake/ollama1";
+            dataDir = "$HOME/.services-flake/ollama1";
           };
           # Get ChatGPT like UI, but open-source, with Open WebUI
           open-webui."open-webui1" = {
@@ -43,7 +43,8 @@
                 RAG_EMBEDDING_ENGINE = "ollama";
                 RAG_EMBEDDING_MODEL = "mxbai-embed-large:latest";
                 RAG_EMBEDDING_MODEL_AUTO_UPDATE = "True";
-                RAG_RERANKING_MODEL_AUTO_UPDATE = "True";              };
+                RAG_RERANKING_MODEL_AUTO_UPDATE = "True";
+              };
           };
         };
 

--- a/example/llm/flake.nix
+++ b/example/llm/flake.nix
@@ -21,12 +21,20 @@
           # Backend service to perform inference on LLM models
           ollama."ollama1" = {
             enable = true;
+
             # The models are usually huge, downloading them in every project
             # directory can lead to a lot of duplication. Change here to a
             # directory where the Ollama models can be stored and shared across
             # projects.
             dataDir = "$HOME/.services-flake/ollama1";
+
+            # Define the models to download when our app starts
+            # 
+            # You can also initialize this to empty list, and download the
+            # models manually in the UI.
+            models = [ "llama2-uncensored" ];
           };
+
           # Get ChatGPT like UI, but open-source, with Open WebUI
           open-webui."open-webui1" = {
             enable = true;


### PR DESCRIPTION
This reverts a couple of changes from #227

cf. https://nixos.zulipchat.com/#narrow/stream/414011-services-flake/topic/.E2.9C.94.20Require.20opinion.20on.20.60example.2Fllm.60