### PR TITLE
searxng: init

### DIFF
--- a/doc/searxng.md
+++ b/doc/searxng.md
@@ -1,0 +1,20 @@
+# Searxng
+
+[Searxng](https://github.com/searxng/searxng) is a free internet metasearch engine which aggregates results from various search services and databases. Users are neither tracked nor profiled.
+
+## Getting Started
+
+```nix
+# In `perSystem.process-compose.<name>`
+{
+  services.searxng."instance-name" = {
+    enable = true;
+    settings = {
+      use_default_settings = true;
+      server.port = 1234;
+      server.bind_address = "127.0.0.1";
+      server.secret_key = "foobar";
+    };
+  };
+}
+```

--- a/doc/searxng.md
+++ b/doc/searxng.md
@@ -9,11 +9,12 @@
 {
   services.searxng."instance-name" = {
     enable = true;
+    port = 1234;
+    host = "127.0.0.1";
+    secret_key = "my-secret-key";
     settings = {
-      use_default_settings = true;
-      server.port = 1234;
-      server.bind_address = "127.0.0.1";
-      server.secret_key = "foobar";
+      doi_resolvers."dummy" = "http://example.org";
+      default_doi_resolver = "dummy";
     };
   };
 }

--- a/example/llm/flake.nix
+++ b/example/llm/flake.nix
@@ -31,7 +31,7 @@
             dataDir = "${dataDirBase}/ollama1";
 
             # Define the models to download when our app starts
-            # 
+            #
             # You can also initialize this to empty list, and download the
             # models manually in the UI.
             #

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,5 +21,6 @@ in
     ./cassandra.nix
     ./tempo.nix
     ./weaviate.nix
+    ./searxng.nix
   ];
 }

--- a/nix/searxng.nix
+++ b/nix/searxng.nix
@@ -7,20 +7,6 @@
 let
   inherit (lib) types;
   yamlFormat = pkgs.formats.yaml { };
-
-  settingType =
-    with types;
-    (oneOf [
-      bool
-      int
-      float
-      str
-      (listOf settingType)
-      (attrsOf settingType)
-    ])
-    // {
-      description = "JSON value";
-    };
 in
 {
   options = {
@@ -40,7 +26,7 @@ in
     };
 
     settings = lib.mkOption {
-      types = yamlFormat.type;
+      type = yamlFormat.type;
       default = {
         server.secret_key = "secret";
         server.limiter = false;
@@ -65,14 +51,12 @@ in
         processes = {
           "${name}" = {
             environment = {
-              SEARXNG_SETTINGS_PATH = "${pkgs.writeText "settings.yml" (
-                builtins.toJSON (
-                  lib.recursiveUpdate config.settings {
-                    use_default_settings = true;
-                    server.bind_address = config.host;
-                    server.port = config.port;
-                  }
-                )
+              SEARXNG_SETTINGS_PATH = "${yamlFormat.generate "settings.yaml" (
+                lib.recursiveUpdate config.settings {
+                  use_default_settings = true;
+                  server.bind_address = config.host;
+                  server.port = config.port;
+                }
               )}";
             };
             command = lib.getExe config.package;

--- a/nix/searxng.nix
+++ b/nix/searxng.nix
@@ -38,8 +38,7 @@ in
         }
       '';
       description = ''
-        Searxng settings. These will be merged with (taking precedence over)
-        the default configuration.
+        Searxng settings
       '';
     };
 

--- a/nix/searxng.nix
+++ b/nix/searxng.nix
@@ -1,9 +1,4 @@
-{ pkgs
-, lib
-, name
-, config
-, ...
-}:
+{ pkgs, lib, name, config, ... }:
 let
   inherit (lib) types;
   yamlFormat = pkgs.formats.yaml { };

--- a/nix/searxng.nix
+++ b/nix/searxng.nix
@@ -20,6 +20,12 @@ in
       type = types.port;
     };
 
+    use_default_settings = lib.mkOption {
+      description = "Use default Searxng settings";
+      default = true;
+      type = types.bool;
+    };
+
     settings = lib.mkOption {
       type = yamlFormat.type;
       default = {
@@ -47,9 +53,9 @@ in
             environment = {
               SEARXNG_SETTINGS_PATH = "${yamlFormat.generate "settings.yaml" (
                 lib.recursiveUpdate config.settings {
-                  use_default_settings = true;
                   server.bind_address = config.host;
                   server.port = config.port;
+                  use_default_settings = config.use_default_settings;
                 }
               )}";
             };

--- a/nix/searxng.nix
+++ b/nix/searxng.nix
@@ -26,16 +26,20 @@ in
       type = types.bool;
     };
 
+    secret_key = lib.mkOption {
+      description = "Searxng secret key";
+      default = "secret";
+      example = "secret-key";
+      type = types.str;
+    };
+
     settings = lib.mkOption {
       type = yamlFormat.type;
-      default = {
-        server.secret_key = "secret";
-        server.limiter = false;
-      };
+      default = { };
       example = lib.literalExpression ''
         {
-          server.secret_key = "secret";
-          server.limiter = false;
+        doi_resolvers."dummy" = "http://example.org";
+        default_doi_resolver = "dummy";
         }
       '';
       description = ''
@@ -55,6 +59,7 @@ in
                 lib.recursiveUpdate config.settings {
                   server.bind_address = config.host;
                   server.port = config.port;
+                  server.secret_key = config.secret_key;
                   use_default_settings = config.use_default_settings;
                 }
               )}";

--- a/nix/searxng.nix
+++ b/nix/searxng.nix
@@ -1,0 +1,94 @@
+{ pkgs
+, lib
+, name
+, config
+, ...
+}:
+let
+  inherit (lib) types;
+  yamlFormat = pkgs.formats.yaml { };
+
+  settingType =
+    with types;
+    (oneOf [
+      bool
+      int
+      float
+      str
+      (listOf settingType)
+      (attrsOf settingType)
+    ])
+    // {
+      description = "JSON value";
+    };
+in
+{
+  options = {
+    enable = lib.mkEnableOption name;
+    package = lib.mkPackageOption pkgs "searxng" { };
+
+    host = lib.mkOption {
+      description = "Searxng bind address";
+      default = "127.0.0.1";
+      type = types.str;
+    };
+
+    port = lib.mkOption {
+      description = "Searxng port to listen on";
+      default = 8080;
+      type = types.port;
+    };
+
+    settings = lib.mkOption {
+      types = yamlFormat.type;
+      default = {
+        server.secret_key = "secret";
+        server.limiter = false;
+      };
+      example = lib.literalExpression ''
+        {
+          server.secret_key = "secret";
+          server.limiter = false;
+        }
+      '';
+      description = ''
+        Searxng settings. These will be merged with (taking precedence over)
+        the default configuration.
+      '';
+    };
+
+    outputs.settings = lib.mkOption {
+      type = types.deferredModule;
+      internal = true;
+      readOnly = true;
+      default = {
+        processes = {
+          "${name}" = {
+            environment = {
+              SEARXNG_SETTINGS_PATH = "${pkgs.writeText "settings.yml" (
+                builtins.toJSON (
+                  lib.recursiveUpdate config.settings {
+                    use_default_settings = true;
+                    server.bind_address = config.host;
+                    server.port = config.port;
+                  }
+                )
+              )}";
+            };
+            command = lib.getExe config.package;
+            namespace = name;
+            availability.restart = "on_failure";
+            readiness_probe = {
+              exec.command = "${lib.getExe pkgs.curl} -f -k http://${config.host}:${toString config.port}";
+              initial_delay_seconds = 5;
+              period_seconds = 10;
+              timeout_seconds = 2;
+              success_threshold = 1;
+              failure_threshold = 5;
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/searxng_test.nix
+++ b/nix/searxng_test.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+{
+  services.searxng."searxng1".enable = true;
+
+  settings.processes.test = {
+    command = pkgs.writeShellApplication {
+      runtimeInputs = [ pkgs.curl ];
+      text = ''
+        curl http://127.0.0.1:8080
+      '';
+      name = "searxng-test";
+    };
+    depends_on."searxng1".condition = "process_healthy";
+  };
+}

--- a/nix/searxng_test.nix
+++ b/nix/searxng_test.nix
@@ -4,7 +4,6 @@
     enable = true;
     use_default_settings = false;
     settings = {
-      server.secret_key = "secret";
       doi_resolvers."dummy" = "http://example.org";
       default_doi_resolver = "dummy";
     };

--- a/nix/searxng_test.nix
+++ b/nix/searxng_test.nix
@@ -1,6 +1,14 @@
 { pkgs, ... }:
 {
-  services.searxng."searxng1".enable = true;
+  services.searxng."searxng1" = {
+    enable = true;
+    use_default_settings = false;
+    settings = {
+      server.secret_key = "secret";
+      doi_resolvers."dummy" = "http://example.org";
+      default_doi_resolver = "dummy";
+    };
+  };
 
   settings.processes.test = {
     command = pkgs.writeShellApplication {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -49,10 +49,11 @@
             "${inputs.services-flake}/nix/cassandra_test.nix"
             "${inputs.services-flake}/nix/tempo_test.nix"
             "${inputs.services-flake}/nix/weaviate_test.nix"
-            "${inputs.services-flake}/nix/searxng_test.nix"
           ] ++ lib.optionals pkgs.stdenv.isLinux [
             # Broken on Darwin: https://github.com/NixOS/nixpkgs/issues/316954
             "${inputs.services-flake}/nix/grafana_test.nix"
+            # Broken on Darwin: https://github.com/NixOS/nixpkgs/issues/321329
+            "${inputs.services-flake}/nix/searxng_test.nix"
           ]));
       };
     };

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -49,6 +49,7 @@
             "${inputs.services-flake}/nix/cassandra_test.nix"
             "${inputs.services-flake}/nix/tempo_test.nix"
             "${inputs.services-flake}/nix/weaviate_test.nix"
+            "${inputs.services-flake}/nix/searxng_test.nix"
           ] ++ lib.optionals pkgs.stdenv.isLinux [
             # Broken on Darwin: https://github.com/NixOS/nixpkgs/issues/316954
             "${inputs.services-flake}/nix/grafana_test.nix"


### PR DESCRIPTION
This PR:

- [x] Add the `searxng` service

Test with:

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
    flake-parts.url = "github:hercules-ci/flake-parts";
    systems.url = "github:nix-systems/default";
    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
    services-flake.url = "github:juspay/services-flake";
  };
  outputs =
    inputs:
    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
      systems = import inputs.systems;
      imports = [ inputs.process-compose-flake.flakeModule ];
      perSystem =
        { pkgs, lib, ... }:
        {
          # `process-compose.foo` will add a flake package output called "foo".
          # Therefore, this will add a default package that you can build using
          # `nix build` and run using `nix run`.
          process-compose."default" =
            pc:
            let
              inherit (pc.config.services.searxng.searxng) host port;
            in
            {
              imports = [ inputs.services-flake.processComposeModules.default ];

              services.searxng."searxng" = {
                enable = true;
                settings = {
                  use_default_settings = true;
                  server.secret_key = "secret";
                  server.limiter = false;
                };
              };

              # Open the browser after the Open WebUI service has started
              settings.processes.open-browser = {
                command =
                  let
                    opener = if pkgs.stdenv.isDarwin then "open" else lib.getExe' pkgs.xdg-utils "xdg-open";
                    url = "http://${host}:${toString port}";
                  in
                  "${opener} ${url}";
                depends_on.searxng.condition = "process_healthy";
              };
            };
        };
    };
}
```