### PR TITLE
tika: add `enableOcr` option

### DIFF
--- a/nix/services/tika.nix
+++ b/nix/services/tika.nix
@@ -44,7 +44,7 @@ in
           "${name}" =
             let
               tikaPackage = config.package.override {
-                enableOcr = config.enableOcr;
+                inherit (config) enableOcr;
               };
             in
             {


### PR DESCRIPTION
Following `nixpkgs` PR @ https://github.com/NixOS/nixpkgs/pull/327886, this PR add the `enableOcr` option.