### PR TITLE
elasticsearch: copy plugins to `dataDir`

### DIFF
--- a/nix/services/elasticsearch.nix
+++ b/nix/services/elasticsearch.nix
@@ -147,8 +147,11 @@ in
                 export ES_HOME ES_JAVA_OPTS ES_PATH_CONF
 
                 # Install plugins
-                rm -f "${config.dataDir}/plugins"
-                ln -sf ${esPlugins}/plugins "${config.dataDir}/plugins"
+                rm -rf "${config.dataDir}/plugins"
+                cp -rL ${esPlugins}/plugins "${config.dataDir}/plugins"
+                find "${config.dataDir}/plugins" -type f -exec chmod 0700 {} \;
+                find "${config.dataDir}/plugins" -type d -exec chmod 0700 {} \;
+
                 rm -f "${config.dataDir}/lib"
                 ln -sf ${config.package}/lib "${config.dataDir}/lib"
                 rm -f "${config.dataDir}/modules"

--- a/nix/services/elasticsearch.nix
+++ b/nix/services/elasticsearch.nix
@@ -149,7 +149,6 @@ in
                 # Install plugins
                 rm -rf "${config.dataDir}/plugins"
                 cp -rL ${esPlugins}/plugins "${config.dataDir}/plugins"
-                find "${config.dataDir}/plugins" -type f -exec chmod 0700 {} \;
                 find "${config.dataDir}/plugins" -type d -exec chmod 0700 {} \;
 
                 rm -f "${config.dataDir}/lib"

--- a/nix/services/elasticsearch.nix
+++ b/nix/services/elasticsearch.nix
@@ -149,7 +149,7 @@ in
                 # Install plugins
                 rm -rf "${config.dataDir}/plugins"
                 cp -rL ${esPlugins}/plugins "${config.dataDir}/plugins"
-                find "${config.dataDir}/plugins" -type d -exec chmod 0700 {} \;
+                find "${config.dataDir}/plugins" -type d -exec chmod u+x {} \;
 
                 rm -f "${config.dataDir}/lib"
                 ln -sf ${config.package}/lib "${config.dataDir}/lib"

--- a/nix/services/elasticsearch_test.nix
+++ b/nix/services/elasticsearch_test.nix
@@ -1,11 +1,19 @@
 { pkgs, config, ... }: {
-  services.elasticsearch."es1".enable = true;
+  services.elasticsearch."es1" = {
+    enable = true;
+    plugins = [
+      pkgs.elasticsearchPlugins.analysis-icu
+    ];
+  };
   settings.processes.test =
     {
       command = pkgs.writeShellApplication {
         runtimeInputs = [ pkgs.curl ];
         text = ''
           curl 127.0.0.1:9200/_cat/health 
+
+          echo "Verify plugin installation"
+          curl 127.0.0.1:9200/_cat/plugins | grep 'analysis-icu'
         '';
         name = "elasticsearch-test";
       };


### PR DESCRIPTION
resolves #325 