### PR TITLE
fix(elasticsearch): Fixed permission to add to directories in elasticsearch plugins

### DIFF
--- a/nix/services/elasticsearch.nix
+++ b/nix/services/elasticsearch.nix
@@ -149,7 +149,7 @@ in
                 # Install plugins
                 rm -rf "${config.dataDir}/plugins"
                 cp -rL ${esPlugins}/plugins "${config.dataDir}/plugins"
-                find "${config.dataDir}/plugins" -type d -exec chmod u+x {} \;
+                find "${config.dataDir}/plugins" -type d -exec chmod u+w {} \;
 
                 rm -f "${config.dataDir}/lib"
                 ln -sf ${config.package}/lib "${config.dataDir}/lib"


### PR DESCRIPTION
We need to add the write permission to directories in elasticsearch plugins, not execute, which they already have.

Sorry @shivaraj-bh this was a typo in my suggestion in #331 