### PR TITLE
chore(mongodb): Use `mongodb-ce`; Enable test on `darwin`

### DIFF
--- a/doc/mongodb.md
+++ b/doc/mongodb.md
@@ -6,6 +6,22 @@ Because of the licensing of MongoDB, the Nixpkgs derivation that provides the bi
 
 If you are using this for your own development, you should either put in place a [local binary cache](https://nixos.wiki/wiki/Binary_Cache) to match your flake, or be aware that the first time you spin up the service it could possibly take a long time to build.
 
+## Pre-built binaries
+
+[mongodb-ce](https://github.com/NixOS/nixpkgs/blob/e58a261efb95afd52fb4a1cf35185a017327a96d/pkgs/by-name/mo/mongodb-ce/package.nix) package from [nixpkgs](https://github.com/NixOS/nixpkgs) fetches pre-built binaries[^why-pre-built]. You can also build the binary from scratch using [mongodb](https://github.com/NixOS/nixpkgs/blob/924e8aa12419c6ac57690ed47c1d9af580c818a2/pkgs/servers/nosql/mongodb/mongodb.nix) package:
+
+```nix
+# Inside `process-compose.<name>`
+{
+  services.mongodb."m1" = {
+    enable = true;
+    package = pkgs.mongodb;
+  };
+}
+```
+
+[why-pre-built]: For more context on why pre-built binary is used, see: https://github.com/juspay/services-flake/pull/360
+
 ## Usage example
 
 <https://github.com/juspay/services-flake/blob/main/nix/services/mongodb_test.nix>

--- a/nix/services/mongodb.nix
+++ b/nix/services/mongodb.nix
@@ -4,7 +4,7 @@ let
 in
 {
   options = {
-    package = lib.mkPackageOption pkgs "mongodb" { };
+    package = lib.mkPackageOption pkgs "mongodb-ce" { };
 
     bind = lib.mkOption {
       type = types.nullOr types.str;

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -38,6 +38,7 @@
             "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
             "${inputs.services-flake}/nix/services/grafana_test.nix"
             "${inputs.services-flake}/nix/services/memcached_test.nix"
+            "${inputs.services-flake}/nix/services/mongodb_test.nix"
             "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"
             "${inputs.services-flake}/nix/services/ollama_test.nix"
             "${inputs.services-flake}/nix/services/open-webui_test.nix"
@@ -51,10 +52,6 @@
             "${inputs.services-flake}/nix/services/tika_test.nix"
             "${inputs.services-flake}/nix/services/weaviate_test.nix"
             "${inputs.services-flake}/nix/services/zookeeper_test.nix"
-          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-            # Due to a dependency problem, MongoDB does not build on Darwin,
-            # See https://github.com/NixOS/nixpkgs/issues/346003
-            "${inputs.services-flake}/nix/services/mongodb_test.nix"
           ]));
       };
     };


### PR DESCRIPTION
`mongodb-ce` fetches pre-built binaries.

The previously used `mongodb` package had to be built from scratch because of license restrictions, see: https://github.com/juspay/services-flake/pull/339#issuecomment-2377968085