### PR TITLE
fix(clickhouse-init): kill `clickhouse-server` on `EXIT`

### DIFF
--- a/nix/services/clickhouse/bad_test.sql
+++ b/nix/services/clickhouse/bad_test.sql
@@ -1,0 +1,2 @@
+CREATE STABLE sample_db.ride (`id` Int64, `short_id` String) ENGINE = MergeTree() PRIMARY KEY (id);
+

--- a/nix/services/clickhouse/clickhouse_test.nix
+++ b/nix/services/clickhouse/clickhouse_test.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }: {
+{ pkgs, config, name, ... }: {
   services.clickhouse."clickhouse1" = {
     enable = true;
     port = 9000;
@@ -15,16 +15,29 @@
       }
     ];
   };
+  services.clickhouse."clickhouse3" = {
+    enable = true;
+    port = 9002;
+    extraConfig.http_port = 9052;
+    initialDatabases = [
+      {
+        name = "sample_db";
+        schemas = [ ./bad_test.sql ];
+      }
+    ];
+  };
 
   # avoid both the processes trying to create `data` directory at the same time
   settings.processes."clickhouse2-init".depends_on."clickhouse1-init".condition = "process_completed_successfully";
+  settings.processes."clickhouse3-init".depends_on."clickhouse2-init".condition = "process_completed_successfully";
+
   settings.processes.test =
     let
       cfg = config.services.clickhouse."clickhouse1";
     in
     {
       command = pkgs.writeShellApplication {
-        runtimeInputs = [ cfg.package pkgs.gnugrep pkgs.curl ];
+        runtimeInputs = [ cfg.package pkgs.gnugrep pkgs.curl pkgs.jq ];
         text =
           let
             # Tests based on: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/clickhouse.nix
@@ -42,9 +55,13 @@
 
             # schemas test
             clickhouse-client --host 127.0.0.1 --port 9001 --query "SELECT * FROM sample_db.ride WHERE short_id = 'test_ride';" | grep test_ride
+
+            # Test if `clickhouse3-init` fails due to `bad_test.sql`
+            curl --unix-socket pc-${name}.sock http://localhost/process/logs/clickhouse3-init/30/0 | jq '.logs | any(. | startswith("Code: 62. DB::Exception: Syntax error"))' | grep "true"
           '';
         name = "clickhouse-test";
       };
       depends_on."clickhouse2".condition = "process_healthy";
+      depends_on."clickhouse3-init".condition = "process_completed";
     };
 }

--- a/nix/services/clickhouse/default.nix
+++ b/nix/services/clickhouse/default.nix
@@ -118,12 +118,14 @@ in
                         echo "Clickhouse is setting up the initial database."
                         set -m
                         clickhouse-server --config-file=${clickhouseConfig} &
+
+                        job_pid=$!
+                        trap 'kill $job_pid' EXIT
+
                         sleep 5s
                         echo "Clickhouse server started."
                         ${setupInitialDatabases}
                         echo "Clickhouse db setting is done."
-                        kill %1
-                        echo "Clickhouse server stopped."
                     fi
                   '';
                 };


### PR DESCRIPTION
fixes #361 