### PR TITLE
chore(nix): Remove treefmt

### DIFF
--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -15,22 +15,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -64,45 +48,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1729755165,
@@ -131,40 +76,14 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks-nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -180,8 +99,7 @@
         "flake-root": "flake-root",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "services-flake": "services-flake",
-        "treefmt-nix": "treefmt-nix"
+        "services-flake": "services-flake"
       }
     },
     "services-flake": {
@@ -196,39 +114,6 @@
       "original": {
         "owner": "juspay",
         "repo": "services-flake",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1688916551,
-        "narHash": "sha256-YsGzTjtYwJ7j8TTIjo0cImycGAvUT1UXq2sCZ8Vu0Wc=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "3fadb6baac68068dc0196f35d3e092bf316d4409",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -3,12 +3,8 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
-    pre-commit-hooks-nix = {
-      url = "github:cachix/pre-commit-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-stable.follows = "nixpkgs";
-    };
+    pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
+    pre-commit-hooks-nix.flake = false;
     cachix-push.url = "github:juspay/cachix-push";
 
     # CI will override `services-flake` to run checks on the latest source
@@ -19,22 +15,11 @@
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
         inputs.flake-root.flakeModule
-        inputs.treefmt-nix.flakeModule
-        inputs.pre-commit-hooks-nix.flakeModule
+        (inputs.pre-commit-hooks-nix + /flake-module.nix)
         inputs.cachix-push.flakeModule
         ./nix/pre-commit.nix
       ];
       perSystem = { self', pkgs, config, ... }: {
-        treefmt = {
-          projectRoot = inputs.services-flake;
-          projectRootFile = "flake.nix";
-          # Even though pre-commit-hooks.nix checks it, let's have treefmt-nix
-          # check as well until #238 is fully resolved.
-          # flakeCheck = false; # pre-commit-hooks.nix checks this
-          programs = {
-            nixpkgs-fmt.enable = true;
-          };
-        };
         cachix-push = {
           cacheName = "services-flake";
           pathsToCache = {
@@ -48,7 +33,6 @@
             config.pre-commit.settings.tools.commitizen
           ];
           inputsFrom = [
-            config.treefmt.build.devShell
             config.pre-commit.devShell
           ];
           shellHook = ''

--- a/dev/nix/pre-commit.nix
+++ b/dev/nix/pre-commit.nix
@@ -5,7 +5,7 @@
       check.enable = true;
       settings = {
         hooks = {
-          treefmt.enable = true;
+          nixpkgs-fmt.enable = true;
           commitizen.enable = true;
         };
       };

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ ex-share-services:
 
 # Auto-format the project tree
 fmt:
-    treefmt
+    pre-commit run -a
 
 # Run native tests for all the services
 [group('test')]


### PR DESCRIPTION
We already use pre-commit and that supports nixpkgs-fmt.

cf. https://github.com/srid/haskell-template/pull/144

Also, this PR updates git-hooks.nix while making a non-flake thereby reducing the number of lock file (`dev/flake.lock`) entries.