### PR TITLE
chore(test): disable elasticsearch on darwin

### DIFF
--- a/test/flake.nix
+++ b/test/flake.nix
@@ -42,7 +42,6 @@
             "${inputs.services-flake}/nix/services/apache-kafka_test.nix"
             "${inputs.services-flake}/nix/services/cassandra_test.nix"
             "${inputs.services-flake}/nix/services/clickhouse/clickhouse_test.nix"
-            "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
             "${inputs.services-flake}/nix/services/grafana_test.nix"
             "${inputs.services-flake}/nix/services/memcached_test.nix"
             "${inputs.services-flake}/nix/services/minio_test.nix"
@@ -62,6 +61,10 @@
             "${inputs.services-flake}/nix/services/tika_test.nix"
             "${inputs.services-flake}/nix/services/weaviate_test.nix"
             "${inputs.services-flake}/nix/services/zookeeper_test.nix"
+          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            # Fails on macOS with: `error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted`
+            # Related: https://github.com/NixOS/nix/issues/6765
+            "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
           ]));
       };
     };


### PR DESCRIPTION
Fails on macOS with: 
```sh
error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted
```
Related: https://github.com/NixOS/nix/issues/6765