### PR TITLE
feat: Portable services

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,17 @@
 {
   description = "declarative, composable, and reproducible services for Nix development environment";
-  outputs = _: {
-    processComposeModules.default = ./nix/services;
+  outputs = _:
+    let modules = import ./nix/services; in {
+      processComposeModules.default = modules.processComposeModules;
+      homeModules.default = modules.homeModules;
 
-    templates.default = {
-      description = "Example flake using process-compose-flake";
-      path = builtins.path { path = ./example/simple; filter = path: _: baseNameOf path == "flake.nix"; };
+      templates.default = {
+        description = "Example flake using process-compose-flake";
+        path = builtins.path { path = ./example/simple; filter = path: _: baseNameOf path == "flake.nix"; };
+      };
+
+      lib = import ./nix/lib.nix;
+
+      om = import ./nix/omnix.nix;
     };
-
-    lib = import ./nix/lib.nix;
-
-    om = import ./nix/omnix.nix;
-  };
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -4,7 +4,7 @@
   # where module filename is of form `${name}.nix`. The submodule takes this
   # 'name' parameter, and is expected to set the final process-compose config in
   # its `outputs.settings` option.
-  multiService = mod:
+  multiService = process-manager-name: mod:
     { config, pkgs, lib, ... }:
     let
       # Derive name from filename
@@ -16,11 +16,13 @@
       serviceModule = { config, name, ... }: {
         options = {
           enable = lib.mkEnableOption "Enable the ${service}.<name> service";
+          # FIXME: process-compose option
           dataDir = lib.mkOption {
             type = lib.types.str;
             default = "./data/${name}";
             description = "The directory where all data for `${service}.<name>` is stored";
           };
+          # FIXME: process-compose option
           namespace = lib.mkOption {
             description = ''
               Namespace for the ${service} service
@@ -29,6 +31,8 @@
             type = lib.types.str;
           };
           outputs = {
+            # FIXME: Need better distinction for process-manager specific options.
+            # I also don't think this option should be under `outputs`.
             defaultProcessSettings = lib.mkOption {
               type = lib.types.deferredModule;
               internal = true;
@@ -40,6 +44,7 @@
                 namespace = lib.mkDefault config.namespace;
               };
             };
+            # FIXME: rename to `process-compose`
             settings = lib.mkOption {
               type = lib.types.lazyAttrsOf lib.types.raw;
               internal = true;
@@ -51,6 +56,16 @@
                   { imports = [ config.outputs.defaultProcessSettings cfg ]; }
                 );
               };
+            };
+            systemd = lib.mkOption {
+              type = lib.types.lazyAttrsOf lib.types.deferredModule;
+              internal = true;
+              default = { };
+            };
+            launchd = lib.mkOption {
+              type = lib.types.lazyAttrsOf lib.types.deferredModule;
+              internal = true;
+              default = { };
             };
           };
         };
@@ -72,7 +87,19 @@
           });
         };
       };
-      config = {
+      config = lib.optionalAttrs (process-manager-name == "launchd")
+        {
+          launchd.agents = lib.pipe config.services.${service} [
+            (lib.concatMapAttrs (_: cfg: lib.mapAttrs (_: cf: { ... }: { imports = [ cf ]; }) cfg.outputs.launchd))
+          ];
+        }
+      // lib.optionalAttrs (process-manager-name == "systemd") {
+        systemd.user.services = lib.pipe config.services.${service} [
+          (lib.filterAttrs (_: cfg: cfg.enable))
+          (lib.concatMapAttrs (_: cfg: cfg.outputs.systemd))
+        ];
+      }
+      // lib.optionalAttrs (process-manager-name == "process-compose") {
         settings = {
           imports =
             lib.pipe config.services.${service} [

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -16,13 +16,13 @@
       serviceModule = { config, name, ... }: {
         options = {
           enable = lib.mkEnableOption "Enable the ${service}.<name> service";
-          # FIXME: process-compose option
+          # FIXME: `multiService` lib should be devoid of process-compose specific options
           dataDir = lib.mkOption {
             type = lib.types.str;
             default = "./data/${name}";
             description = "The directory where all data for `${service}.<name>` is stored";
           };
-          # FIXME: process-compose option
+          # FIXME: `multiService` lib should be devoid of process-compose specific options
           namespace = lib.mkOption {
             description = ''
               Namespace for the ${service} service
@@ -31,8 +31,7 @@
             type = lib.types.str;
           };
           outputs = {
-            # FIXME: Need better distinction for process-manager specific options.
-            # I also don't think this option should be under `outputs`.
+            # FIXME: `multiService` lib should be devoid of process-compose specific options
             defaultProcessSettings = lib.mkOption {
               type = lib.types.deferredModule;
               internal = true;

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -1,8 +1,6 @@
 let
   inherit (import ../lib.nix) multiService;
-in
-{
-  imports = (builtins.map multiService [
+  services = [
     ./apache-kafka.nix
     ./clickhouse
     ./elasticsearch.nix
@@ -26,8 +24,14 @@ in
     ./weaviate.nix
     ./searxng.nix
     ./tika.nix
-  ]) ++ [
-    ./devshell.nix
   ];
+in
+{
+  processComposeModules = {
+    imports = (builtins.map (multiService "process-compose") services) ++ [ ./devShell.nix ];
+  };
 
+  homeModules = {
+    imports = (builtins.map (multiService "systemd") services) ++ (builtins.map (multiService "launchd") services);
+  };
 }

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -28,10 +28,15 @@ let
 in
 {
   processComposeModules = {
-    imports = (builtins.map (multiService "process-compose") services) ++ [ ./devShell.nix ];
+    imports = (builtins.map (multiService "processComposeModules") services) ++ [ ./devShell.nix ];
   };
 
   homeModules = {
-    imports = (builtins.map (multiService "systemd") services) ++ (builtins.map (multiService "launchd") services);
+    imports = (builtins.map (multiService "homeModules") services);
+    # imports = lib.pipe services [
+    #   (map (multiService "systemd"))
+    #   (map (multiService "launchd"))
+    # ];
+    # imports = (builtins.map (multiService "systemd") services) ++ (builtins.map (multiService "launchd") services);
   };
 }

--- a/nix/services/ollama.nix
+++ b/nix/services/ollama.nix
@@ -74,6 +74,24 @@ in
 
   config = {
     outputs = {
+      launchd = {
+        "${name}" = lib.mkIf pkgs.stdenv.isDarwin {
+          config = {
+            enable = config.enable;
+            config = {
+              ProgramArguments = [ (lib.getExe config.package) "serve" ];
+              EnvironmentVariables = config.environment // {
+                OLLAMA_HOST = "${config.host}:${toString config.port}";
+              };
+              KeepAlive = {
+                Crashed = true;
+                SuccessfulExit = false;
+              };
+              ProcessType = "Background";
+            };
+          };
+        };
+      };
       settings = {
         processes = {
           "${name}" =

--- a/nix/services/ollama.nix
+++ b/nix/services/ollama.nix
@@ -74,6 +74,20 @@ in
 
   config = {
     outputs = {
+      # systemd and launchd config based on https://github.com/nix-community/home-manager/blob/5031c6d2978109336637977c165f82aa49fa16a7/modules/services/ollama.nix#L78-L108
+      # TODO: refactor to reuse between all three outputs and also set sane defaults for `systemd` and `launchd`, just like `defaultProcessSettings`.
+      systemd."${name}" = lib.mkIf pkgs.stdenv.isLinux {
+        Unit = {
+          After = [ "network.target" ];
+        };
+        Service = {
+          ExecStart = "${lib.getExe ollamaPackage} serve";
+          Environment =
+            (lib.mapAttrsToList (n: v: "${n}=${v}") config.environment)
+            ++ [ "OLLAMA_HOST=${config.host}:${toString config.port}" ];
+        };
+        Install = { WantedBy = [ "default.target" ]; };
+      };
       launchd = {
         "${name}" = lib.mkIf pkgs.stdenv.isDarwin {
           config = {


### PR DESCRIPTION
resolves #354 

Init with `ollama`.

## Usage

### process-compose app

```nix
# Inside perSystem
{
  process-compose.sf-ollama = {
    imports = [ inputs.services-flake.processComposeModules.default ];
    services.ollama.”o1”.enable = true;
  };
}
```
And `nix run .#sf-ollama` to start the service

### `systemd`/`launchd` user unit/agent

> Note: The option `services.<service-name>` overlaps with existing service definitions in `home-manager`. I could rename it to avoid conflict, but for now you could use the `release-24.11` branch of `home-manager` that doesn’t yet have `ollama`. 

```nix
# In your `homeConfiguration`
{
  imports = [ inputs.services-flake.homeModules.default ];
  services.ollama.”o1”.enable = true;
}
```

Lastly, activate your home-manager config...


<Insert home-manager template to test `Ollama` running via `systemd` or `launchd`>

TODO:
- [ ] `outputs.{systemd, launchd, process-compose}` must share as much configuration as possible (also add sane defaults for `systemd` and `launchd`)
- [ ] `systemd` and `launchd` tests
- [ ] Documentation
