### PR TITLE
fix(mysql): allow hyphens in database names

### DIFF
--- a/nix/services/mysql/default.nix
+++ b/nix/services/mysql/default.nix
@@ -238,9 +238,9 @@ in
                     )"
                     if [[ "$exists" -eq 0 ]]; then
                       echo "Creating initial database: ${database.name}"
-                      ( echo "create database ${database.name};"
+                      ( echo "create database \`${database.name}\`;"
                         ${lib.optionalString (database.schema != null) ''
-                      echo "use ${database.name};"
+                      echo "use \`${database.name}\`;"
                       # TODO: this silently falls through if database.schema does not exist,
                       # we should catch this somehow and exit, but can't do it here because we're in a subshell.
                       if [ -f "${database.schema}" ]

--- a/nix/services/mysql/mysql_test.nix
+++ b/nix/services/mysql/mysql_test.nix
@@ -24,6 +24,8 @@
     };
   services.mysql.m3 = {
     enable = true;
+    # Test whether `-` is allowed in a database name. See https://github.com/juspay/services-flake/issues/513
+    initialDatabases = [{ name = "test-database"; }];
     importTimeZones = true;
     package = pkgs.mysql80;
     settings.mysqld.port = 3309;
@@ -88,6 +90,12 @@
             echo "success! baz table not found"
           else
             echo "baz table shoudn't exist"
+            exit 1
+          fi
+
+          databases_count=$(echo "SHOW DATABASES LIKE 'test-database';" | MYSQL_PWD="" mysql -h 127.0.0.1 -P 3309 -u root | wc -l)
+          if [ "$databases_count" -eq 0 ]; then
+            echo "test-database doesn't exist in m3"
             exit 1
           fi
         '';


### PR DESCRIPTION
MySQL service rejected DB names containing “-”, although MariaDB allows them. Fixes #513