### PR TITLE
feat: add support for phpfpm

### DIFF
--- a/doc/phpfpm.md
+++ b/doc/phpfpm.md
@@ -1,0 +1,40 @@
+# PHP FastCGI Process Manager
+
+[PHP FPM](https://www.php.net/manual/en/book.fpm.php) (FastCGI Process Manager) is a primary PHP FastCGI implementation containing some features (mostly) useful for heavy-loaded sites.
+
+## Unix socket
+
+PHP FPM supports the usage of [Unix socket](https://man7.org/linux/man-pages/man2/socket.2.html) to listen to connections. By default, the socket `phpfpm.sock` will be used.
+
+```nix
+# Inside `process-compose.<name>`
+{
+  services.phpfpm."php1" = {
+    enable = true;
+    extraConfig = {
+      "pm" = "ondemand";
+      "pm.max_children" = 1;
+    };
+  };
+}
+```
+
+## TCP port
+
+```nix
+# Inside `process-compose.<name>`
+{
+  services.phpfpm."php1" = {
+    enable = true;
+    listen = 9000;
+    extraConfig = {
+      "pm" = "ondemand";
+      "pm.max_children" = 1;
+    };
+  };
+}
+```
+
+## Usage example
+
+<https://github.com/juspay/services-flake/blob/main/nix/services/phpfpm_test.nix>

--- a/doc/services.md
+++ b/doc/services.md
@@ -18,6 +18,7 @@ short-title: Services
 - [[nginx]]#
 - [[ollama]]#
 - [[open-webui]]#
+- [[phpfpm]]#
 - [[postgresql]]#
   - [[pgadmin]]
 - [[prometheus]]#

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -26,6 +26,7 @@ in
     ./weaviate.nix
     ./searxng.nix
     ./tika.nix
+    ./phpfpm.nix
   ]) ++ [
     ./devshell.nix
   ];

--- a/nix/services/phpfpm.nix
+++ b/nix/services/phpfpm.nix
@@ -1,0 +1,151 @@
+{ config
+, lib
+, name
+, pkgs
+, ...
+}:
+let
+  inherit (lib) types;
+
+  toStr =
+    value:
+    if true == value then
+      "yes"
+    else if false == value then
+      "no"
+    else
+      toString value;
+
+  configType =
+    with types;
+    attrsOf (oneOf [
+      str
+      int
+      bool
+    ]);
+in
+{
+  options = {
+    package = lib.mkPackageOption pkgs "php" { };
+
+    listen = lib.mkOption {
+      type = types.either types.port types.str;
+      default = "phpfpm.sock";
+      description = ''
+        The address on which to accept FastCGI requests.
+      '';
+    };
+
+    phpOptions = lib.mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        date.timezone = "CET"
+      '';
+      description = ''
+        Options appended to the PHP configuration file {file}`php.ini` used for this PHP-FPM pool.
+      '';
+    };
+
+    phpEnv = lib.mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Environment variables used for this PHP-FPM pool.
+      '';
+      example = lib.literalExpression ''
+        {
+          HOSTNAME = "$HOSTNAME";
+          TMP = "/tmp";
+          TMPDIR = "/tmp";
+          TEMP = "/tmp";
+        }
+      '';
+    };
+
+    extraConfig = lib.mkOption {
+      type = configType;
+      default = { };
+      description = ''
+        PHP-FPM pool directives. Refer to the "List of pool directives" section of
+        <https://www.php.net/manual/en/install.fpm.configuration.php>
+        for details. Note that settings names must be enclosed in quotes (e.g.
+        `"pm.max_children"` instead of `pm.max_children`).
+      '';
+      example = lib.literalExpression ''
+        {
+          "pm" = "dynamic";
+          "pm.max_children" = 75;
+          "pm.start_servers" = 10;
+          "pm.min_spare_servers" = 5;
+          "pm.max_spare_servers" = 20;
+          "pm.max_requests" = 500;
+        }
+      '';
+    };
+  };
+  config = {
+    extraConfig.listen = lib.mkDefault config.listen;
+
+    outputs.settings = {
+      processes.${name} =
+        let
+          cfgFile = pkgs.writeText "phpfpm-${name}.conf" ''
+            [global]
+            daemonize = no
+            error_log = /proc/self/fd/2
+
+            [${name}]
+            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") config.extraConfig)}
+            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "env[${n}] = ${toStr v}") config.phpEnv)}
+          '';
+          iniFile =
+            pkgs.runCommand "php.ini"
+              {
+                inherit (config) phpOptions;
+                preferLocalBuild = true;
+                passAsFile = [ "phpOptions" ];
+              }
+              ''
+                cat ${config.package}/etc/php.ini $phpOptionsPath > $out
+              '';
+        in
+        {
+          command = pkgs.writeShellApplication {
+            name = "start-phpfpm";
+            runtimeInputs = [ config.package ];
+            text = ''
+              DATA_DIR="$(readlink -m ${config.dataDir})"
+              if [[ ! -d "$DATA_DIR" ]]; then
+                mkdir -p "$DATA_DIR"
+              fi
+              exec php-fpm -p "$DATA_DIR" -y ${cfgFile} -c ${iniFile}
+            '';
+          };
+
+          readiness_probe =
+            let
+              # Transform `listen` by prefixing `config.dataDir` if a relative path is used
+              transformedListen =
+                if (builtins.isString config.listen && (! lib.hasPrefix "/" config.listen)) then
+                  "${config.dataDir}/${config.listen}"
+                else
+                  config.listen;
+            in
+            {
+              exec.command =
+                if (builtins.isInt config.listen) then
+                  "${pkgs.fcgi}/bin/cgi-fcgi -bind -connect 127.0.0.1:${toString config.listen}"
+                else
+                  "${pkgs.fcgi}/bin/cgi-fcgi -bind -connect ${transformedListen}";
+
+              initial_delay_seconds = 2;
+              period_seconds = 10;
+              timeout_seconds = 4;
+              success_threshold = 1;
+              failure_threshold = 5;
+            };
+        };
+    };
+  };
+}

--- a/nix/services/phpfpm_test.nix
+++ b/nix/services/phpfpm_test.nix
@@ -1,0 +1,45 @@
+{ pkgs, config, ... }: {
+  services.phpfpm."phpfpm1" = {
+    enable = true;
+    listen = "phpfpm.sock";
+    extraConfig = {
+      "pm" = "ondemand";
+      "pm.max_children" = 1;
+    };
+    phpOptions = ''
+      date.timezone = "CET"
+    '';
+    phpEnv = {
+      TMPDIR = "/tmp";
+    };
+  };
+
+  services.phpfpm."phpfpm2" = {
+    enable = true;
+    listen = 9000;
+    extraConfig = {
+      "pm" = "ondemand";
+      "pm.max_children" = 1;
+    };
+  };
+
+  settings.processes.test =
+    let
+      cfg = config.services.phpfpm."phpfpm1";
+    in
+    {
+      command = pkgs.writeShellApplication {
+        runtimeInputs = [ cfg.package pkgs.fcgi ];
+        text = ''
+          echo "Test connection to phpfpm1 listening on Unix socket"
+          cgi-fcgi -bind -connect ./data/phpfpm1/phpfpm.sock
+
+          echo "Test connection to phpfpm2 listening on port 9000"
+          cgi-fcgi -bind -connect 127.0.0.1:9000
+        '';
+        name = "phpfpm-test";
+      };
+      depends_on."phpfpm1".condition = "process_healthy";
+      depends_on."phpfpm2".condition = "process_healthy";
+    };
+}

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -54,6 +54,7 @@
             "${inputs.services-flake}/nix/services/ollama_test.nix"
             "${inputs.services-flake}/nix/services/open-webui_test.nix"
             "${inputs.services-flake}/nix/services/pgadmin_test.nix"
+            "${inputs.services-flake}/nix/services/phpfpm_test.nix"
             "${inputs.services-flake}/nix/services/postgres/postgres_test.nix"
             "${inputs.services-flake}/nix/services/prometheus_test.nix"
             "${inputs.services-flake}/nix/services/redis_test.nix"


### PR DESCRIPTION
I wanted to run WordPress via process compose and had to add phpfpm to achieve this. It is mainly based on the [NixOS module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-servers/phpfpm/default.nix), but simplified a bit.