### PR TITLE
fix(postgres): Quote `unix_socket_directories` argument

### DIFF
--- a/nix/services/postgres/setup-script.nix
+++ b/nix/services/postgres/setup-script.nix
@@ -129,7 +129,7 @@ in
 
       trap 'pg_ctl -D "$PGDATA" -m fast -w stop' EXIT
 
-      pg_ctl -D "$PGDATA" -w start -o "-c unix_socket_directories=$PGHOST -c listen_addresses= -p ${toString config.port}"
+      pg_ctl -D "$PGDATA" -w start -o "-c unix_socket_directories=\"$PGHOST\" -c listen_addresses= -p ${toString config.port}"
 
       ${runInitialScript.before}
       ${setupInitialDatabases}


### PR DESCRIPTION
Wrapped `PGHOST` with `"` for `unix_socket_directories.

Resolves #532.
| Initial | After |
|---------|-------|
| ![Screenshot 2025-06-06 at 15 09 18](https://github.com/user-attachments/assets/68ef8778-6c6c-4825-82b0-0a61fbde9d6b) | ![Screenshot 2025-06-06 at 15 12 47](https://github.com/user-attachments/assets/b314f765-89c3-4365-a72b-1d964172362f) |

In the Initial image the error is because of the asbsolute path getting broken into 2 argsuments.
```sh
pg_ctl -D ./data/pg2 -w start -o '-c unix_socket_directories=/Users/nikhil.singh/work/services flake/test/test/new/ socket/path/pg-init-m2GRBV -c listen_addresses= -p 5433'
waiting for server to start....postgres: invalid argument: "flake/test/test/new/socket/path/pg-init-m2GRBV"
Try "postgres --help" for more information.
```

Where as in After it states that 
```sh
Listening on Unix socket "/Users/nikhil.singh/work/services flake/test/test/new/socket/path3/.s.PGSQL.5432"
```