### PR TITLE
feat: Add global settings option to phpfpm

### DIFF
--- a/nix/services/phpfpm.nix
+++ b/nix/services/phpfpm.nix
@@ -83,6 +83,24 @@ in
         }
       '';
     };
+
+    globalSettings = lib.mkOption {
+      type = configType;
+      default = { };
+      description = ''
+        PHP-FPM global directives. Refer to the "List of global php-fpm.conf directives" section of
+        <https://www.php.net/manual/en/install.fpm.configuration.php>
+        for details. Note that settings names must be enclosed in quotes (e.g.
+        `"pm.max_children"` instead of `pm.max_children`).
+        Do not specify the options `error_log` or
+        `daemonize` here, since they are generated.
+      '';
+      example = lib.literalExpression ''
+        {
+          "log_level" = "debug";
+        }
+      '';
+    };
   };
   config = {
     extraConfig.listen = lib.mkDefault config.listen;
@@ -94,6 +112,7 @@ in
             [global]
             daemonize = no
             error_log = /proc/self/fd/2
+            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") config.globalSettings)}
 
             [${name}]
             ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") config.extraConfig)}

--- a/nix/services/phpfpm.nix
+++ b/nix/services/phpfpm.nix
@@ -108,11 +108,13 @@ in
     outputs.settings = {
       processes.${name} =
         let
+          mergedGlobalSettings = {
+            "daemonize" = false;
+            "error_log" = "/proc/self/fd/2";
+          } // config.globalSettings;
           cfgFile = pkgs.writeText "phpfpm-${name}.conf" ''
             [global]
-            daemonize = no
-            error_log = /proc/self/fd/2
-            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") config.globalSettings)}
+            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") mergedGlobalSettings)}
 
             [${name}]
             ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") config.extraConfig)}

--- a/nix/services/phpfpm_test.nix
+++ b/nix/services/phpfpm_test.nix
@@ -12,6 +12,9 @@
     phpEnv = {
       TMPDIR = "/tmp";
     };
+    globalSettings = {
+      "log_level" = "debug";
+    };
   };
 
   services.phpfpm."phpfpm2" = {


### PR DESCRIPTION
Add a "settings" option to the phpfpm module.
This allows changing global settings such as
the logging level.

The existing "extraConfig" option sets the pool
settings, but cannot set global settings.

The option name "settings" is taken from the
NixOS Module.