### PR TITLE
fix(phpfpm): Health checks fails when env is large

### DIFF
--- a/nix/services/phpfpm.nix
+++ b/nix/services/phpfpm.nix
@@ -154,11 +154,14 @@ in
                   config.listen;
             in
             {
+              # php-fpm can ignore requests that are too large, so we
+              # use env -i to remove all environment variables.
+              # See https://github.com/php/php-src/issues/16042
               exec.command =
                 if (builtins.isInt config.listen) then
-                  "${pkgs.fcgi}/bin/cgi-fcgi -bind -connect 127.0.0.1:${toString config.listen}"
+                  "env -i ${pkgs.fcgi}/bin/cgi-fcgi -bind -connect 127.0.0.1:${toString config.listen}"
                 else
-                  "${pkgs.fcgi}/bin/cgi-fcgi -bind -connect ${transformedListen}";
+                  "env -i ${pkgs.fcgi}/bin/cgi-fcgi -bind -connect ${transformedListen}";
 
               initial_delay_seconds = 2;
               period_seconds = 10;


### PR DESCRIPTION
When the total environment is too large, such as
over 8KB, FastCGI closes the connection with
no output or log messages. cgi-fcgi returns with
an exit code of 104 and no output.

This happens even when clear_env is set in the
PHP-FPM config, since the problem seems to happen
before that would be applied.

To fix this, we prefix the cgi-fcgi command with
`env -i` to clear the environment.