### PR TITLE
fix(postgres): quote `dataDir` to prevent word splitting

### DIFF
--- a/nix/services/postgres/setup-script.nix
+++ b/nix/services/postgres/setup-script.nix
@@ -72,7 +72,7 @@ let
   initdbArgs =
     config.initdbArgs
     ++ (lib.optionals (config.superuser != null) [ "-U" config.superuser ])
-    ++ [ "-D" config.dataDir ];
+    ++ [ "-D" "\"${config.dataDir}\"" ];
 in
 (pkgs.writeShellApplication {
   name = "setup-postgres";


### PR DESCRIPTION
Escape seq fix, similar to #533