### PR TITLE
feat(cassandra): Add `storagePort` option

### DIFF
--- a/nix/services/cassandra.nix
+++ b/nix/services/cassandra.nix
@@ -21,6 +21,12 @@ in
       default = 9042;
     };
 
+    storagePort = lib.mkOption {
+      type = types.port;
+      description = "port for the storage engine to listen for clients on";
+      default = 7000;
+    };
+
     seedAddresses = lib.mkOption {
       type = types.listOf types.str;
       default = [ "127.0.0.1" ];
@@ -67,6 +73,7 @@ in
         start_native_transport = config.allowClients;
         listen_address = config.listenAddress;
         native_transport_port = config.nativeTransportPort;
+        storage_port = config.storagePort;
         commitlog_sync = "batch";
         commitlog_sync_batch_window_in_ms = 2;
         cluster_name = config.clusterName;

--- a/nix/services/cassandra_test.nix
+++ b/nix/services/cassandra_test.nix
@@ -1,9 +1,9 @@
 { pkgs, config, ... }: {
   services.cassandra."cass1" = {
     enable = true;
-    # support for aarch64-darwin was added in cassandra-4
-    # https://github.com/apache/cassandra/blob/a87055d56a33a9b17606f14535f48eb461965b82/CHANGES.txt#L192
-    package = pkgs.cassandra_4;
+    package = pkgs.cassandra;
+    # Port 7000 is reserved on macOS (used by AirPlay/Bonjour), so use 7001
+    storagePort = 7001;
   };
 
   settings.processes.test =


### PR DESCRIPTION
Both cassandra and macOS bind to 7000 so in order to run the tests successfully on macOS we need to rebind that port.
