### PR TITLE
elasticmq: init

### DIFF
--- a/doc/elasticmq.md
+++ b/doc/elasticmq.md
@@ -1,0 +1,7 @@
+# ElasticMQ
+
+[ElasticMQ](https://github.com/softwaremill/elasticmq) is a message queue system, offering an actor-based Scala and an SQS-compatible REST (query) interface.
+
+## Usage example
+
+<https://github.com/juspay/services-flake/blob/main/nix/services/elasticmq_test.nix>

--- a/doc/services.md
+++ b/doc/services.md
@@ -9,6 +9,7 @@ short-title: Services
 - [[cassandra]]#
 - [[clickhouse]]#
 - [[dynamodb-local]]#
+- [[elasticmq]]#
 - [[elasticsearch]]#
 - [[grafana]]#
   - [[tempo]]

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -7,6 +7,7 @@ in
     ./azurite.nix
     ./clickhouse
     ./dynamodb-local.nix
+    ./elasticmq.nix
     ./elasticsearch.nix
     ./mongodb.nix
     ./mysql

--- a/nix/services/elasticmq.nix
+++ b/nix/services/elasticmq.nix
@@ -1,0 +1,135 @@
+{ config, pkgs, lib, name, ... }:
+{
+  options = {
+    package = lib.mkPackageOption pkgs "elasticmq-server-bin" { };
+
+    nodeAddress = {
+      protocol = lib.mkOption {
+        type = lib.types.str;
+        default = "http";
+      };
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost";
+      };
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 9324;
+      };
+      contextPath = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+      };
+    };
+
+    restSqs = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+          };
+          bindPort = lib.mkOption {
+            type = lib.types.port;
+            default = 9324;
+          };
+          bindHost = lib.mkOption {
+            type = lib.types.str;
+            default = "0.0.0.0";
+          };
+        };
+      };
+      default = { };
+    };
+
+    restStats = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+          };
+          bindPort = lib.mkOption {
+            type = lib.types.port;
+            default = 9325;
+          };
+          bindHost = lib.mkOption {
+            type = lib.types.str;
+            default = "0.0.0.0";
+          };
+        };
+      };
+      default = { };
+    };
+
+    generateNodeAddress = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+
+    extraOptions = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = "Additional raw HOCON options to append.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Extra args to pass down to ElasticMQ.
+      '';
+    };
+  };
+
+  config.outputs.settings.processes."${name}" =
+    let
+      confFile = pkgs.writeText "elasticmq.conf" ''
+        node-address.protocol = ${config.nodeAddress.protocol}
+        node-address.host = ${config.nodeAddress.host}
+        node-address.port = ${toString config.nodeAddress.port}
+        node-address.context-path = "${config.nodeAddress.contextPath}"
+
+        rest-sqs.enabled = ${lib.boolToString config.restSqs.enable}
+        rest-sqs.bind-port = ${toString config.restSqs.bindPort}
+        rest-sqs.bind-hostname = "${config.restSqs.bindHost}"
+
+        rest-stats.enabled = ${lib.boolToString config.restStats.enable}
+        rest-stats.bind-port = ${toString config.restStats.bindPort}
+        rest-stats.bind-hostname = "${config.restStats.bindHost}"
+
+        generate-node-address = ${lib.boolToString config.generateNodeAddress}
+
+        ${config.extraOptions}
+      '';
+      startCommand = pkgs.writeShellApplication {
+        name = "start-elasticmq";
+        runtimeEnv = {
+          JAVA_TOOL_OPTIONS = "-Dconfig.file=${confFile}";
+        };
+        text = ''
+          exec ${lib.getExe config.package} ${lib.escapeShellArgs config.extraArgs}
+        '';
+      };
+    in
+    {
+      command = startCommand;
+      readiness_probe = lib.optionalAttrs config.restSqs.enable {
+        http_get = {
+          host = "127.0.0.1";
+          port = config.restSqs.bindPort;
+          path = "/health";
+        };
+        initial_delay_seconds = 2;
+        period_seconds = 10;
+        timeout_seconds = 4;
+        success_threshold = 1;
+        failure_threshold = 5;
+      };
+      # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
+      availability = {
+        restart = "on_failure";
+        max_restarts = 5;
+      };
+    };
+}

--- a/nix/services/elasticmq_test.nix
+++ b/nix/services/elasticmq_test.nix
@@ -1,0 +1,29 @@
+{ pkgs
+, config
+, ...
+}: {
+  services.elasticmq."elasticmq1" = {
+    enable = true;
+  };
+
+  settings.processes.test =
+    let
+      inherit (config.services.elasticmq."elasticmq1".restSqs) bindHost bindPort;
+    in
+    {
+      command = pkgs.writeShellApplication {
+        name = "elasticmq-test";
+        runtimeInputs = with pkgs; [ awscli2 jq ];
+        runtimeEnv = {
+          AWS_ACCESS_KEY_ID = "fake";
+          AWS_SECRET_ACCESS_KEY = "fake";
+          AWS_DEFAULT_REGION = "us-east-1";
+        };
+        text = ''
+          aws sqs list-queues --endpoint-url "http://${bindHost}:${toString bindPort}" \
+          | jq '.QueueUrls'
+        '';
+      };
+      depends_on."elasticmq1".condition = "process_healthy";
+    };
+}

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -45,6 +45,7 @@
             "${inputs.services-flake}/nix/services/cassandra_test.nix"
             "${inputs.services-flake}/nix/services/clickhouse/clickhouse_test.nix"
             "${inputs.services-flake}/nix/services/dynamodb-local_test.nix"
+            "${inputs.services-flake}/nix/services/elasticmq_test.nix"
             "${inputs.services-flake}/nix/services/grafana_test.nix"
             "${inputs.services-flake}/nix/services/memcached_test.nix"
             "${inputs.services-flake}/nix/services/minio_test.nix"


### PR DESCRIPTION
https://github.com/softwaremill/elasticmq

Adding ElasticMQ, an AWS SQS compatible, in-memory message queue system. Rest SQS must be enabled to run health check.