### PR TITLE
fix(dynamodb-local): fix check on inMemory to allow setting dbPath

### DIFF
--- a/nix/services/dynamodb-local.nix
+++ b/nix/services/dynamodb-local.nix
@@ -34,8 +34,8 @@
       '';
       apply =
         v:
-        lib.throwIf (config.dbPath != null) ''
-          You can't specify both -dbPath and -inMemory at once.
+        lib.throwIf (config.dbPath != null && v) ''
+          You can't specify both dbPath and set inMemory to true at once.
         ''
           v;
     };

--- a/nix/services/dynamodb-local_test.nix
+++ b/nix/services/dynamodb-local_test.nix
@@ -7,9 +7,16 @@
     inMemory = true;
   };
 
+  services.dynamodb-local."dynamodb2" = {
+    enable = true;
+    port = 8001;
+    dbPath = "/tmp/dynamodb2";
+  };
+
   settings.processes.test =
     let
-      cfg = config.services.dynamodb-local."dynamodb1";
+      cfg1 = config.services.dynamodb-local."dynamodb1";
+      cfg2 = config.services.dynamodb-local."dynamodb2";
     in
     {
       command = pkgs.writeShellApplication {
@@ -21,10 +28,13 @@
           AWS_DEFAULT_REGION = "us-east-1";
         };
         text = ''
-          aws dynamodb list-tables --endpoint-url "http://127.0.0.1:${toString cfg.port}" \
+          aws dynamodb list-tables --endpoint-url "http://127.0.0.1:${toString cfg1.port}" \
+          | jq '.TableNames'
+          aws dynamodb list-tables --endpoint-url "http://127.0.0.1:${toString cfg2.port}" \
           | jq '.TableNames'
         '';
       };
       depends_on."dynamodb1".condition = "process_healthy";
+      depends_on."dynamodb2".condition = "process_healthy";
     };
 }


### PR DESCRIPTION
What changed?
Adjusted the check in the dynamodb-local service so that the inMemory flag and dbPath setting are evaluated correctly.
Added appropriate test(s) to cover both modes and ensure dbPath can be set when inMemory = false.
