### PR TITLE
test(mysql): re-enable on aarch64-darwin

### DIFF
--- a/test/flake.nix
+++ b/test/flake.nix
@@ -49,6 +49,7 @@
             "${inputs.services-flake}/nix/services/elasticmq_test.nix"
             "${inputs.services-flake}/nix/services/grafana_test.nix"
             "${inputs.services-flake}/nix/services/memcached_test.nix"
+            "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
             "${inputs.services-flake}/nix/services/nats-server_test.nix"
             "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"
             "${inputs.services-flake}/nix/services/ollama_test.nix"
@@ -77,11 +78,6 @@
             # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to post process the configuration
             # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: FPM initialization failed
             "${inputs.services-flake}/nix/services/phpfpm_test.nix"
-            # `mysql80` package fails to build on aarch64-darwin with:
-            # libc++abi: terminating due to uncaught exception of type std::runtime_error: opening input file: No such file or directory
-            # /nix/store/w3q1nvfb44cmc0a3pdky0654ll7nca7n-signing-utils: line 24: 75907 Abort trap: 6           /nix/store/dqrpsqnanf3cr9nalcnl7pvbdwrqrwfk-sigtool-0.1.3/bin/sigtool --file "$file" check-requires-signature
-            # Unexpected exit status from sigtool: 134
-            "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
             # Fails on macOS with: `error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted`
             # Related: https://github.com/NixOS/nix/issues/6765
             "${inputs.services-flake}/nix/services/elasticsearch_test.nix"


### PR DESCRIPTION
https://github.com/juspay/services-flake/pull/668 updated mysql80 -> mysql84. mysql84 doesn't break on aarch64-darwin like mysql80 did