### PR TITLE
tempo: slim config; support v3;

### DIFF
--- a/nix/services/tempo.nix
+++ b/nix/services/tempo.nix
@@ -67,26 +67,6 @@ in
                     };
                   };
                 };
-                distributor = {
-                  receivers = {
-                    jaeger = {
-                      protocols = {
-                        thrift_http = null;
-                        grpc = null;
-                        thrift_binary = null;
-                        thrift_compact = null;
-                      };
-                    };
-                    zipkin = null;
-                    otlp = {
-                      protocols = {
-                        http = null;
-                        grpc = null;
-                      };
-                    };
-                    opencensus = null;
-                  };
-                };
               }
               config.extraConfig;
             tempoConfigYaml = yamlFormat.generate "tempo.yaml" tempoConfig;


### PR DESCRIPTION
This PR slims the config to just what is required for Tempo's HTTP backend to init and serve requests and also removes blocking and now deprecated config like the opencensus distributor from the generated tempo configuration which unblocks support for Tempo v3