### PR TITLE
feat: add `mailhog` service

### DIFF
--- a/doc/mailhog.md
+++ b/doc/mailhog.md
@@ -1,0 +1,38 @@
+# Mailhog
+
+[Mailhog SMTP server](https://grafana.com/docs/loki/latest/) is Web and API based SMTP testing tool.
+
+## Getting Started
+
+```nix
+# In `perSystem.process-compose.<name>`
+{
+  services.mailhog."mh".enable = true;
+}
+```
+
+{#tips}
+
+## Tips & Tricks
+
+### Send Emails
+
+```bash
+message="$(printf 'From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test email\r\n\r\nThis is a test message sent via curl to MailHog.\r\n')"
+
+echo "Sending email."
+curl -sS smtp://127.0.0.1:1025 \
+        --mail-from "sender@example.com" \
+        --mail-rcpt "recipient@example.com" \
+        --upload-file - <<< "$message"
+```
+
+### Web UI
+
+Inspect [https://localhost:8025](https://localhost:8025).
+
+### Using the API
+
+```bash
+curl http://127.0.0.1:8025/api/v2/messages | jq
+```

--- a/doc/mailhog.md
+++ b/doc/mailhog.md
@@ -1,6 +1,7 @@
 # Mailhog
 
-[Mailhog SMTP server](https://grafana.com/docs/loki/latest/) is Web and API based SMTP testing tool.
+[Mailhog SMTP server](https://github.com/mailhog/MailHog) is a Web and API based SMTP testing tool
+which only runs in RAM and has not storage.
 
 ## Getting Started
 
@@ -29,7 +30,7 @@ curl -sS smtp://127.0.0.1:1025 \
 
 ### Web UI
 
-Inspect [https://localhost:8025](https://localhost:8025).
+Inspect [http://localhost:8025](https://localhost:8025).
 
 ### Using the API
 

--- a/doc/services.md
+++ b/doc/services.md
@@ -16,6 +16,7 @@ short-title: Services
   - [[tempo]]
   - [[loki]]
   - [[pyroscope]]
+- [[mailhog]]#
 - [[memcached]]#
 - [[minio]]#
 - [[mongodb]]#

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -2,44 +2,47 @@ let
   inherit (import ../lib.nix) multiService;
 in
 {
-  imports = (builtins.map multiService [
-    ./apache-kafka.nix
-    ./azurite.nix
-    ./clickhouse
-    ./dynamodb-local.nix
-    ./elasticmq.nix
-    ./elasticsearch.nix
-    ./mongodb.nix
-    ./mysql
-    ./nginx
-    ./ollama.nix
-    ./postgres
-    ./open-webui.nix
-    ./plantuml.nix
-    ./redis-cluster.nix
-    ./redis.nix
-    ./seaweedfs.nix
-    ./zookeeper.nix
-    ./grafana.nix
-    ./memcached.nix
-    ./minio.nix
-    ./nats-server.nix
-    ./prometheus.nix
-    ./pgadmin.nix
-    ./cassandra.nix
-    ./pyroscope.nix
-    ./tempo.nix
-    ./weaviate.nix
-    ./searxng.nix
-    ./tika.nix
-    ./loki.nix
-    ./phpfpm.nix
-    ./pubsub-emulator.nix
-    ./qdrant.nix
-    ./chromadb.nix
-    ./neo4j.nix
-  ]) ++ [
-    ./devshell.nix
-  ];
+  imports =
+    (builtins.map multiService [
+      ./apache-kafka.nix
+      ./azurite.nix
+      ./clickhouse
+      ./dynamodb-local.nix
+      ./elasticmq.nix
+      ./elasticsearch.nix
+      ./mongodb.nix
+      ./mysql
+      ./nginx
+      ./ollama.nix
+      ./postgres
+      ./open-webui.nix
+      ./plantuml.nix
+      ./redis-cluster.nix
+      ./redis.nix
+      ./seaweedfs.nix
+      ./zookeeper.nix
+      ./grafana.nix
+      ./memcached.nix
+      ./minio.nix
+      ./nats-server.nix
+      ./prometheus.nix
+      ./pgadmin.nix
+      ./cassandra.nix
+      ./pyroscope.nix
+      ./tempo.nix
+      ./weaviate.nix
+      ./searxng.nix
+      ./tika.nix
+      ./loki.nix
+      ./phpfpm.nix
+      ./pubsub-emulator.nix
+      ./qdrant.nix
+      ./chromadb.nix
+      ./neo4j.nix
+      ./mailhog.nix
+    ])
+    ++ [
+      ./devshell.nix
+    ];
 
 }

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -2,47 +2,46 @@ let
   inherit (import ../lib.nix) multiService;
 in
 {
-  imports =
-    (builtins.map multiService [
-      ./apache-kafka.nix
-      ./azurite.nix
-      ./clickhouse
-      ./dynamodb-local.nix
-      ./elasticmq.nix
-      ./elasticsearch.nix
-      ./mongodb.nix
-      ./mysql
-      ./nginx
-      ./ollama.nix
-      ./postgres
-      ./open-webui.nix
-      ./plantuml.nix
-      ./redis-cluster.nix
-      ./redis.nix
-      ./seaweedfs.nix
-      ./zookeeper.nix
-      ./grafana.nix
-      ./memcached.nix
-      ./minio.nix
-      ./nats-server.nix
-      ./prometheus.nix
-      ./pgadmin.nix
-      ./cassandra.nix
-      ./pyroscope.nix
-      ./tempo.nix
-      ./weaviate.nix
-      ./searxng.nix
-      ./tika.nix
-      ./loki.nix
-      ./phpfpm.nix
-      ./pubsub-emulator.nix
-      ./qdrant.nix
-      ./chromadb.nix
-      ./neo4j.nix
-      ./mailhog.nix
-    ])
-    ++ [
-      ./devshell.nix
-    ];
+  imports = (builtins.map multiService [
+    ./apache-kafka.nix
+    ./azurite.nix
+    ./clickhouse
+    ./dynamodb-local.nix
+    ./elasticmq.nix
+    ./elasticsearch.nix
+    ./mongodb.nix
+    ./mysql
+    ./nginx
+    ./ollama.nix
+    ./postgres
+    ./open-webui.nix
+    ./plantuml.nix
+    ./redis-cluster.nix
+    ./redis.nix
+    ./seaweedfs.nix
+    ./zookeeper.nix
+    ./grafana.nix
+    ./memcached.nix
+    ./minio.nix
+    ./nats-server.nix
+    ./prometheus.nix
+    ./pgadmin.nix
+    ./cassandra.nix
+    ./pyroscope.nix
+    ./tempo.nix
+    ./weaviate.nix
+    ./searxng.nix
+    ./tika.nix
+    ./loki.nix
+    ./phpfpm.nix
+    ./pubsub-emulator.nix
+    ./qdrant.nix
+    ./chromadb.nix
+    ./neo4j.nix
+    ./mailhog.nix
+  ])
+  ++ [
+    ./devshell.nix
+  ];
 
 }

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -38,7 +38,7 @@ in
         default = "127.0.0.1";
       };
       port = lib.mkOption {
-        type = types.number;
+        type = types.port;
         description = "Port for the UI.";
         default = 8025;
       };
@@ -51,7 +51,7 @@ in
         default = "127.0.0.1";
       };
       port = lib.mkOption {
-        type = types.number;
+        type = types.port;
         description = "Port for the SMTP.";
         default = 1025;
       };

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -66,14 +66,15 @@ in
 
   config.outputs.settings.processes.${name} = {
     command =
-      # Bash
-      ''
-        exec ${lib.getExe cfg.package} \
-          -api-bind-addr '${cfg.api.host}:${toString cfg.api.port}' \
-          -ui-bind-addr '${cfg.ui.host}:${toString cfg.ui.port}' \
-          -smtp-bind-addr '${cfg.smtp.host}:${toString cfg.smtp.port}' \
-          ${lib.escapeShellArgs cfg.extraArgs}
-      '';
+      pkgs.writeShellScriptBin "mailhog"
+        # Bash
+        ''
+          exec ${lib.getExe cfg.package} \
+            -api-bind-addr '${cfg.api.host}:${toString cfg.api.port}' \
+            -ui-bind-addr '${cfg.ui.host}:${toString cfg.ui.port}' \
+            -smtp-bind-addr '${cfg.smtp.host}:${toString cfg.smtp.port}' \
+            ${lib.escapeShellArgs cfg.extraArgs}
+        '';
 
     readiness_probe = {
       http_get = {

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -25,7 +25,7 @@ in
         default = "127.0.0.1";
       };
       port = lib.mkOption {
-        type = types.number;
+        type = types.port;
         description = "Port for the API.";
         default = 8025;
       };
@@ -58,7 +58,7 @@ in
     };
 
     extraArgs = lib.mkOption {
-      type = types.listOf types.lines;
+      type = types.listOf types.str;
       default = [ ];
       example = [ "-invite-jim" ];
       description = ''

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -1,0 +1,94 @@
+{ pkgs
+, lib
+, config
+, name
+, ...
+}:
+
+let
+  cfg = config;
+  types = lib.types;
+in
+{
+  options = {
+    package = lib.mkOption {
+      type = types.package;
+      description = "Which package of mailhog to use";
+      default = pkgs.mailhog;
+      defaultText = lib.literalExpression "pkgs.mailhog";
+    };
+
+    api = {
+      host = lib.mkOption {
+        type = types.str;
+        description = "Host name for the API.";
+        default = "127.0.0.1";
+      };
+      port = lib.mkOption {
+        type = types.number;
+        description = "Port for the API.";
+        default = 8025;
+      };
+    };
+
+    ui = {
+      host = lib.mkOption {
+        type = types.str;
+        description = "Host name for the UI.";
+        default = "127.0.0.1";
+      };
+      port = lib.mkOption {
+        type = types.number;
+        description = "Port for the UI.";
+        default = 8025;
+      };
+    };
+
+    smtp = {
+      host = lib.mkOption {
+        type = types.str;
+        description = "Host name for SMTP.";
+        default = "127.0.0.1";
+      };
+      port = lib.mkOption {
+        type = types.number;
+        description = "Port for the SMTP.";
+        default = 1025;
+      };
+    };
+
+    additionalArgs = lib.mkOption {
+      type = types.listOf types.lines;
+      default = [ ];
+      example = [ "-invite-jim" ];
+      description = ''
+        Additional arguments passed to `mailhog`.
+      '';
+    };
+  };
+
+  config.outputs.settings.processes.${name} = {
+    command =
+      # Bash
+      ''
+        exec ${lib.getExe cfg.package} \
+          -api-bind-addr '${cfg.api.host}:${toString cfg.api.port}' \
+          -ui-bind-addr '${cfg.ui.host}:${toString cfg.ui.port}' \
+          -smtp-bind-addr '${cfg.smtp.host}:${toString cfg.smtp.port}' \
+          ${lib.concatStringsSep " " cfg.additionalArgs}
+      '';
+
+    readiness_probe = {
+      http_get = {
+        host = cfg.api.host;
+        port = cfg.api.port;
+        path = "/api/v2/messages";
+      };
+      initial_delay_seconds = 1;
+      period_seconds = 2;
+      timeout_seconds = 2;
+      success_threshold = 1;
+      failure_threshold = 10;
+    };
+  };
+}

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -11,11 +11,8 @@ let
 in
 {
   options = {
-    package = lib.mkOption {
-      type = types.package;
-      description = "Which package of mailhog to use";
-      default = pkgs.mailhog;
-      defaultText = lib.literalExpression "pkgs.mailhog";
+    package = lib.mkPackageOption pkgs "mailhog" {
+      extraDescription = "The mailhog package to use.";
     };
 
     api = {

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -75,7 +75,7 @@ in
           -api-bind-addr '${cfg.api.host}:${toString cfg.api.port}' \
           -ui-bind-addr '${cfg.ui.host}:${toString cfg.ui.port}' \
           -smtp-bind-addr '${cfg.smtp.host}:${toString cfg.smtp.port}' \
-          ${lib.concatStringsSep " " cfg.additionalArgs}
+          ${lib.escapeShellArgs cfg.additionalArgs}
       '';
 
     readiness_probe = {

--- a/nix/services/mailhog.nix
+++ b/nix/services/mailhog.nix
@@ -57,7 +57,7 @@ in
       };
     };
 
-    additionalArgs = lib.mkOption {
+    extraArgs = lib.mkOption {
       type = types.listOf types.lines;
       default = [ ];
       example = [ "-invite-jim" ];
@@ -75,7 +75,7 @@ in
           -api-bind-addr '${cfg.api.host}:${toString cfg.api.port}' \
           -ui-bind-addr '${cfg.ui.host}:${toString cfg.ui.port}' \
           -smtp-bind-addr '${cfg.smtp.host}:${toString cfg.smtp.port}' \
-          ${lib.escapeShellArgs cfg.additionalArgs}
+          ${lib.escapeShellArgs cfg.extraArgs}
       '';
 
     readiness_probe = {

--- a/nix/services/mailhog_test.nix
+++ b/nix/services/mailhog_test.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+{
+  services.mailhog."mh".enable = true;
+
+  settings.processes.test = {
+    command = pkgs.writeShellApplication {
+      runtimeInputs = [
+        pkgs.curl
+        pkgs.jq
+      ];
+
+      text = ''
+        set -euo pipefail
+
+        message="$(printf 'From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test email\r\n\r\nThis is a test message sent via curl to MailHog.\r\n')"
+
+        echo "Sending email."
+        curl -sS smtp://127.0.0.1:1025 \
+          --mail-from "sender@example.com" \
+          --mail-rcpt "recipient@example.com" \
+          --upload-file - <<< "$message"
+
+        echo "Send exit code: $?"
+
+        echo "Getting message."
+        curl http://127.0.0.1:8025/api/v2/messages | jq -e '.items[] | select(.Content.Headers.Subject[0] == "Test email")'
+      '';
+      name = "mailhog-test";
+    };
+
+    depends_on."mh".condition = "process_healthy";
+  };
+}

--- a/nix/services/mailhog_test.nix
+++ b/nix/services/mailhog_test.nix
@@ -10,8 +10,6 @@
       ];
 
       text = ''
-        set -euo pipefail
-
         message="$(printf 'From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test email\r\n\r\nThis is a test message sent via curl to MailHog.\r\n')"
 
         echo "Sending email."

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -6,97 +6,113 @@
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
   };
-  outputs = inputs:
+  outputs =
+    inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
       imports = [
         inputs.process-compose-flake.flakeModule
         ./nix/pkgs.nix
       ];
-      perSystem = { self', inputs', pkgs, system, lib, ... }: {
-        process-compose =
-          let
-            mkPackageFor = mod:
-              let
-                # Derive name from filename
-                name = lib.pipe mod [
-                  builtins.baseNameOf
-                  (builtins.match "(.*)_test.nix")
-                  builtins.head
-                ];
-              in
-              lib.nameValuePair name {
-                imports = [
-                  inputs.services-flake.processComposeModules.default
-                  mod
-                ];
-                cli = {
-                  options = {
-                    # HTTP server disabled by default but we need it here for tests
-                    no-server = false;
-                    use-uds = true;
-                    unix-socket = "pc-${name}.sock";
+      perSystem =
+        { self'
+        , inputs'
+        , pkgs
+        , system
+        , lib
+        , ...
+        }:
+        {
+          process-compose =
+            let
+              mkPackageFor =
+                mod:
+                let
+                  # Derive name from filename
+                  name = lib.pipe mod [
+                    builtins.baseNameOf
+                    (builtins.match "(.*)_test.nix")
+                    builtins.head
+                  ];
+                in
+                lib.nameValuePair name {
+                  imports = [
+                    inputs.services-flake.processComposeModules.default
+                    mod
+                  ];
+                  cli = {
+                    options = {
+                      # HTTP server disabled by default but we need it here for tests
+                      no-server = false;
+                      use-uds = true;
+                      unix-socket = "pc-${name}.sock";
+                    };
                   };
                 };
-              };
-          in
-          builtins.listToAttrs (builtins.map mkPackageFor ([
-            "${inputs.services-flake}/nix/services/apache-kafka-kraft_test.nix"
-            "${inputs.services-flake}/nix/services/azurite_test.nix"
-            "${inputs.services-flake}/nix/services/chromadb_test.nix"
-            "${inputs.services-flake}/nix/services/clickhouse/clickhouse_test.nix"
-            "${inputs.services-flake}/nix/services/dynamodb-local_test.nix"
-            "${inputs.services-flake}/nix/services/elasticmq_test.nix"
-            "${inputs.services-flake}/nix/services/grafana_test.nix"
-            "${inputs.services-flake}/nix/services/memcached_test.nix"
-            "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
-            "${inputs.services-flake}/nix/services/nats-server_test.nix"
-            "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"
-            "${inputs.services-flake}/nix/services/ollama_test.nix"
-            "${inputs.services-flake}/nix/services/pgadmin_test.nix"
-            "${inputs.services-flake}/nix/services/plantuml_test.nix"
-            "${inputs.services-flake}/nix/services/postgres/postgres_test.nix"
-            "${inputs.services-flake}/nix/services/prometheus_test.nix"
-            "${inputs.services-flake}/nix/services/pubsub-emulator_test.nix"
-            "${inputs.services-flake}/nix/services/qdrant_test.nix"
-            "${inputs.services-flake}/nix/services/neo4j_test.nix"
-            "${inputs.services-flake}/nix/services/redis_test.nix"
-            "${inputs.services-flake}/nix/services/redis-cluster_test.nix"
-            "${inputs.services-flake}/nix/services/searxng_test.nix"
-            "${inputs.services-flake}/nix/services/pyroscope_test.nix"
-            "${inputs.services-flake}/nix/services/tempo_test.nix"
-            "${inputs.services-flake}/nix/services/loki_test.nix"
-            "${inputs.services-flake}/nix/services/tika_test.nix"
-            "${inputs.services-flake}/nix/services/weaviate_test.nix"
-            "${inputs.services-flake}/nix/services/zookeeper_test.nix"
-          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-            # `phpfpm` test fails on aarch64-darwin:
-            # [phpfpm1        ] [28-Jul-2025 13:05:47.512506] DEBUG: pid 90757, fpm_stdio_save_original_stderr(), line 81: saving original STDERR fd: dup()
-            # [phpfpm1        ] [28-Jul-2025 13:05:47.512606] ERROR: pid 90757, fpm_stdio_open_error_log(), line 386: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
-            # [phpfpm1        ] [28-Jul-2025 13:05:47.512647] ERROR: pid 90757, fpm_conf_init_main(), line 1882: failed to post process the configuration
-            # [phpfpm1        ] [28-Jul-2025 13:05:47.512661] ERROR: pid 90757, fpm_init(), line 72: FPM initialization failed
-            # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
-            # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to post process the configuration
-            # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: FPM initialization failed
-            "${inputs.services-flake}/nix/services/phpfpm_test.nix"
-            # Fails on macOS with: `error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted`
-            # Related: https://github.com/NixOS/nix/issues/6765
-            "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
-            # error: Refusing to evaluate package 'postgresql-test-hook' in /nix/store/cqzw8bdv3bjjrvhln6nhc5hk2y0sxqs8-source/pkgs/by-name/po/postgresqlTestHook/package.nix:8 because it is not available on the requested hostPlatform:
-            # hostPlatform.system = "aarch64-darwin"
-            # package.meta.platforms = [ ]
-            # package.meta.badPlatforms = [
-            #   "x86_64-darwin"
-            #   "aarch64-darwin"
-            # ]
-            "${inputs.services-flake}/nix/services/open-webui_test.nix"
-            "${inputs.services-flake}/nix/services/seaweedfs_test.nix" # Darwin build fixed in https://github.com/NixOS/nixpkgs/pull/534897
-          ]
-          # Tests on non-linux host only
-          ++ lib.optionals (!pkgs.stdenv.hostPlatform.isLinux) [
-            # Fails on Linux due to Nix's build sandbox constraints, see https://github.com/NixOS/nixpkgs/issues/377016#issuecomment-2614610914
-            "${inputs.services-flake}/nix/services/mongodb_test.nix"
-          ]));
-      };
+            in
+            builtins.listToAttrs (
+              builtins.map mkPackageFor (
+                [
+                  "${inputs.services-flake}/nix/services/apache-kafka-kraft_test.nix"
+                  "${inputs.services-flake}/nix/services/azurite_test.nix"
+                  "${inputs.services-flake}/nix/services/chromadb_test.nix"
+                  "${inputs.services-flake}/nix/services/clickhouse/clickhouse_test.nix"
+                  "${inputs.services-flake}/nix/services/dynamodb-local_test.nix"
+                  "${inputs.services-flake}/nix/services/elasticmq_test.nix"
+                  "${inputs.services-flake}/nix/services/grafana_test.nix"
+                  "${inputs.services-flake}/nix/services/memcached_test.nix"
+                  "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
+                  "${inputs.services-flake}/nix/services/nats-server_test.nix"
+                  "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"
+                  "${inputs.services-flake}/nix/services/ollama_test.nix"
+                  "${inputs.services-flake}/nix/services/pgadmin_test.nix"
+                  "${inputs.services-flake}/nix/services/plantuml_test.nix"
+                  "${inputs.services-flake}/nix/services/postgres/postgres_test.nix"
+                  "${inputs.services-flake}/nix/services/prometheus_test.nix"
+                  "${inputs.services-flake}/nix/services/pubsub-emulator_test.nix"
+                  "${inputs.services-flake}/nix/services/qdrant_test.nix"
+                  "${inputs.services-flake}/nix/services/neo4j_test.nix"
+                  "${inputs.services-flake}/nix/services/redis_test.nix"
+                  "${inputs.services-flake}/nix/services/redis-cluster_test.nix"
+                  "${inputs.services-flake}/nix/services/searxng_test.nix"
+                  "${inputs.services-flake}/nix/services/pyroscope_test.nix"
+                  "${inputs.services-flake}/nix/services/tempo_test.nix"
+                  "${inputs.services-flake}/nix/services/loki_test.nix"
+                  "${inputs.services-flake}/nix/services/tika_test.nix"
+                  "${inputs.services-flake}/nix/services/weaviate_test.nix"
+                  "${inputs.services-flake}/nix/services/zookeeper_test.nix"
+                  "${inputs.services-flake}/nix/services/mailhog_test.nix"
+                ]
+                ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+                  # `phpfpm` test fails on aarch64-darwin:
+                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512506] DEBUG: pid 90757, fpm_stdio_save_original_stderr(), line 81: saving original STDERR fd: dup()
+                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512606] ERROR: pid 90757, fpm_stdio_open_error_log(), line 386: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
+                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512647] ERROR: pid 90757, fpm_conf_init_main(), line 1882: failed to post process the configuration
+                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512661] ERROR: pid 90757, fpm_init(), line 72: FPM initialization failed
+                  # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
+                  # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to post process the configuration
+                  # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: FPM initialization failed
+                  "${inputs.services-flake}/nix/services/phpfpm_test.nix"
+                  # Fails on macOS with: `error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted`
+                  # Related: https://github.com/NixOS/nix/issues/6765
+                  "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
+                  # error: Refusing to evaluate package 'postgresql-test-hook' in /nix/store/cqzw8bdv3bjjrvhln6nhc5hk2y0sxqs8-source/pkgs/by-name/po/postgresqlTestHook/package.nix:8 because it is not available on the requested hostPlatform:
+                  # hostPlatform.system = "aarch64-darwin"
+                  # package.meta.platforms = [ ]
+                  # package.meta.badPlatforms = [
+                  #   "x86_64-darwin"
+                  #   "aarch64-darwin"
+                  # ]
+                  "${inputs.services-flake}/nix/services/open-webui_test.nix"
+                  "${inputs.services-flake}/nix/services/seaweedfs_test.nix" # Darwin build fixed in https://github.com/NixOS/nixpkgs/pull/534897
+                ]
+                # Tests on non-linux host only
+                ++ lib.optionals (!pkgs.stdenv.hostPlatform.isLinux) [
+                  # Fails on Linux due to Nix's build sandbox constraints, see https://github.com/NixOS/nixpkgs/issues/377016#issuecomment-2614610914
+                  "${inputs.services-flake}/nix/services/mongodb_test.nix"
+                ]
+              )
+            );
+        };
     };
 }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -6,113 +6,98 @@
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
   };
-  outputs =
-    inputs:
+  outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.systems;
       imports = [
         inputs.process-compose-flake.flakeModule
         ./nix/pkgs.nix
       ];
-      perSystem =
-        { self'
-        , inputs'
-        , pkgs
-        , system
-        , lib
-        , ...
-        }:
-        {
-          process-compose =
-            let
-              mkPackageFor =
-                mod:
-                let
-                  # Derive name from filename
-                  name = lib.pipe mod [
-                    builtins.baseNameOf
-                    (builtins.match "(.*)_test.nix")
-                    builtins.head
-                  ];
-                in
-                lib.nameValuePair name {
-                  imports = [
-                    inputs.services-flake.processComposeModules.default
-                    mod
-                  ];
-                  cli = {
-                    options = {
-                      # HTTP server disabled by default but we need it here for tests
-                      no-server = false;
-                      use-uds = true;
-                      unix-socket = "pc-${name}.sock";
-                    };
+      perSystem = { self', inputs', pkgs, system, lib, ... }: {
+        process-compose =
+          let
+            mkPackageFor = mod:
+              let
+                # Derive name from filename
+                name = lib.pipe mod [
+                  builtins.baseNameOf
+                  (builtins.match "(.*)_test.nix")
+                  builtins.head
+                ];
+              in
+              lib.nameValuePair name {
+                imports = [
+                  inputs.services-flake.processComposeModules.default
+                  mod
+                ];
+                cli = {
+                  options = {
+                    # HTTP server disabled by default but we need it here for tests
+                    no-server = false;
+                    use-uds = true;
+                    unix-socket = "pc-${name}.sock";
                   };
                 };
-            in
-            builtins.listToAttrs (
-              builtins.map mkPackageFor (
-                [
-                  "${inputs.services-flake}/nix/services/apache-kafka-kraft_test.nix"
-                  "${inputs.services-flake}/nix/services/azurite_test.nix"
-                  "${inputs.services-flake}/nix/services/chromadb_test.nix"
-                  "${inputs.services-flake}/nix/services/clickhouse/clickhouse_test.nix"
-                  "${inputs.services-flake}/nix/services/dynamodb-local_test.nix"
-                  "${inputs.services-flake}/nix/services/elasticmq_test.nix"
-                  "${inputs.services-flake}/nix/services/grafana_test.nix"
-                  "${inputs.services-flake}/nix/services/memcached_test.nix"
-                  "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
-                  "${inputs.services-flake}/nix/services/nats-server_test.nix"
-                  "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"
-                  "${inputs.services-flake}/nix/services/ollama_test.nix"
-                  "${inputs.services-flake}/nix/services/pgadmin_test.nix"
-                  "${inputs.services-flake}/nix/services/plantuml_test.nix"
-                  "${inputs.services-flake}/nix/services/postgres/postgres_test.nix"
-                  "${inputs.services-flake}/nix/services/prometheus_test.nix"
-                  "${inputs.services-flake}/nix/services/pubsub-emulator_test.nix"
-                  "${inputs.services-flake}/nix/services/qdrant_test.nix"
-                  "${inputs.services-flake}/nix/services/neo4j_test.nix"
-                  "${inputs.services-flake}/nix/services/redis_test.nix"
-                  "${inputs.services-flake}/nix/services/redis-cluster_test.nix"
-                  "${inputs.services-flake}/nix/services/searxng_test.nix"
-                  "${inputs.services-flake}/nix/services/pyroscope_test.nix"
-                  "${inputs.services-flake}/nix/services/tempo_test.nix"
-                  "${inputs.services-flake}/nix/services/loki_test.nix"
-                  "${inputs.services-flake}/nix/services/tika_test.nix"
-                  "${inputs.services-flake}/nix/services/weaviate_test.nix"
-                  "${inputs.services-flake}/nix/services/zookeeper_test.nix"
-                  "${inputs.services-flake}/nix/services/mailhog_test.nix"
-                ]
-                ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-                  # `phpfpm` test fails on aarch64-darwin:
-                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512506] DEBUG: pid 90757, fpm_stdio_save_original_stderr(), line 81: saving original STDERR fd: dup()
-                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512606] ERROR: pid 90757, fpm_stdio_open_error_log(), line 386: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
-                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512647] ERROR: pid 90757, fpm_conf_init_main(), line 1882: failed to post process the configuration
-                  # [phpfpm1        ] [28-Jul-2025 13:05:47.512661] ERROR: pid 90757, fpm_init(), line 72: FPM initialization failed
-                  # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
-                  # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to post process the configuration
-                  # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: FPM initialization failed
-                  "${inputs.services-flake}/nix/services/phpfpm_test.nix"
-                  # Fails on macOS with: `error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted`
-                  # Related: https://github.com/NixOS/nix/issues/6765
-                  "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
-                  # error: Refusing to evaluate package 'postgresql-test-hook' in /nix/store/cqzw8bdv3bjjrvhln6nhc5hk2y0sxqs8-source/pkgs/by-name/po/postgresqlTestHook/package.nix:8 because it is not available on the requested hostPlatform:
-                  # hostPlatform.system = "aarch64-darwin"
-                  # package.meta.platforms = [ ]
-                  # package.meta.badPlatforms = [
-                  #   "x86_64-darwin"
-                  #   "aarch64-darwin"
-                  # ]
-                  "${inputs.services-flake}/nix/services/open-webui_test.nix"
-                  "${inputs.services-flake}/nix/services/seaweedfs_test.nix" # Darwin build fixed in https://github.com/NixOS/nixpkgs/pull/534897
-                ]
-                # Tests on non-linux host only
-                ++ lib.optionals (!pkgs.stdenv.hostPlatform.isLinux) [
-                  # Fails on Linux due to Nix's build sandbox constraints, see https://github.com/NixOS/nixpkgs/issues/377016#issuecomment-2614610914
-                  "${inputs.services-flake}/nix/services/mongodb_test.nix"
-                ]
-              )
-            );
-        };
+              };
+          in
+          builtins.listToAttrs (builtins.map mkPackageFor ([
+            "${inputs.services-flake}/nix/services/apache-kafka-kraft_test.nix"
+            "${inputs.services-flake}/nix/services/azurite_test.nix"
+            "${inputs.services-flake}/nix/services/chromadb_test.nix"
+            "${inputs.services-flake}/nix/services/clickhouse/clickhouse_test.nix"
+            "${inputs.services-flake}/nix/services/dynamodb-local_test.nix"
+            "${inputs.services-flake}/nix/services/elasticmq_test.nix"
+            "${inputs.services-flake}/nix/services/grafana_test.nix"
+            "${inputs.services-flake}/nix/services/mailhog_test.nix"
+            "${inputs.services-flake}/nix/services/memcached_test.nix"
+            "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
+            "${inputs.services-flake}/nix/services/nats-server_test.nix"
+            "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"
+            "${inputs.services-flake}/nix/services/ollama_test.nix"
+            "${inputs.services-flake}/nix/services/pgadmin_test.nix"
+            "${inputs.services-flake}/nix/services/plantuml_test.nix"
+            "${inputs.services-flake}/nix/services/postgres/postgres_test.nix"
+            "${inputs.services-flake}/nix/services/prometheus_test.nix"
+            "${inputs.services-flake}/nix/services/pubsub-emulator_test.nix"
+            "${inputs.services-flake}/nix/services/qdrant_test.nix"
+            "${inputs.services-flake}/nix/services/neo4j_test.nix"
+            "${inputs.services-flake}/nix/services/redis_test.nix"
+            "${inputs.services-flake}/nix/services/redis-cluster_test.nix"
+            "${inputs.services-flake}/nix/services/searxng_test.nix"
+            "${inputs.services-flake}/nix/services/pyroscope_test.nix"
+            "${inputs.services-flake}/nix/services/tempo_test.nix"
+            "${inputs.services-flake}/nix/services/loki_test.nix"
+            "${inputs.services-flake}/nix/services/tika_test.nix"
+            "${inputs.services-flake}/nix/services/weaviate_test.nix"
+            "${inputs.services-flake}/nix/services/zookeeper_test.nix"
+          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            # `phpfpm` test fails on aarch64-darwin:
+            # [phpfpm1        ] [28-Jul-2025 13:05:47.512506] DEBUG: pid 90757, fpm_stdio_save_original_stderr(), line 81: saving original STDERR fd: dup()
+            # [phpfpm1        ] [28-Jul-2025 13:05:47.512606] ERROR: pid 90757, fpm_stdio_open_error_log(), line 386: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
+            # [phpfpm1        ] [28-Jul-2025 13:05:47.512647] ERROR: pid 90757, fpm_conf_init_main(), line 1882: failed to post process the configuration
+            # [phpfpm1        ] [28-Jul-2025 13:05:47.512661] ERROR: pid 90757, fpm_init(), line 72: FPM initialization failed
+            # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to open error_log (/proc/self/fd/2): No such file or directory (2)
+            # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: failed to post process the configuration
+            # [phpfpm2        ] [28-Jul-2025 13:05:47] ERROR: FPM initialization failed
+            "${inputs.services-flake}/nix/services/phpfpm_test.nix"
+            # Fails on macOS with: `error: chmod '"/nix/store/rcx3n94ygmd61rrv2p22sykhk0yx49n4-elasticsearch-7.17.16/modules/x-pack-ml/platform/darwin-aarch64/controller.app"': Operation not permitted`
+            # Related: https://github.com/NixOS/nix/issues/6765
+            "${inputs.services-flake}/nix/services/elasticsearch_test.nix"
+            # error: Refusing to evaluate package 'postgresql-test-hook' in /nix/store/cqzw8bdv3bjjrvhln6nhc5hk2y0sxqs8-source/pkgs/by-name/po/postgresqlTestHook/package.nix:8 because it is not available on the requested hostPlatform:
+            # hostPlatform.system = "aarch64-darwin"
+            # package.meta.platforms = [ ]
+            # package.meta.badPlatforms = [
+            #   "x86_64-darwin"
+            #   "aarch64-darwin"
+            # ]
+            "${inputs.services-flake}/nix/services/open-webui_test.nix"
+            "${inputs.services-flake}/nix/services/seaweedfs_test.nix" # Darwin build fixed in https://github.com/NixOS/nixpkgs/pull/534897
+          ]
+          # Tests on non-linux host only
+          ++ lib.optionals (!pkgs.stdenv.hostPlatform.isLinux) [
+            # Fails on Linux due to Nix's build sandbox constraints, see https://github.com/NixOS/nixpkgs/issues/377016#issuecomment-2614610914
+            "${inputs.services-flake}/nix/services/mongodb_test.nix"
+          ]));
+      };
     };
 }


### PR DESCRIPTION
Adds the `mailhog` testing SMTP service.

Assisted-by: no agent.

- [x] Documentation
- [x] Tests