### PR TITLE
Add Mimir

### DIFF
--- a/doc/mimir.md
+++ b/doc/mimir.md
@@ -1,0 +1,42 @@
+# Grafana Mimir
+
+[Grafana Mimir](https://grafana.com/docs/mimir/latest/) is an open-source, horizontally scalable,
+highly available, multi-tenant time series database that provides long-term storage for Prometheus.
+
+## Getting Started
+
+```nix
+# In `perSystem.process-compose.<name>`
+{
+  services.mimir."mi1".enable = true;
+}
+```
+
+By default the service runs in monolithic mode (`-target=all`) with filesystem storage under its
+[[datadir]].
+
+{#tips}
+
+## Tips & Tricks
+
+{#usage-with-grafana}
+
+### Usage with Grafana
+
+To add mimir as a Prometheus datasource to #[[grafana]], we can use the following config:
+
+```nix
+{
+  services.mimir.mi1.enable = true;
+  services.grafana.gf1 = {
+    enable = true;
+    datasources = with config.services.mimir.mi1; [{
+      name = "Mimir";
+      type = "prometheus";
+      access = "proxy";
+      url = "http://${httpAddress}:${builtins.toString httpPort}/prometheus";
+    }];
+  };
+  settings.processes."gf1".depends_on."mi1".condition = "process_healthy";
+}
+```

--- a/doc/services.md
+++ b/doc/services.md
@@ -16,6 +16,7 @@ short-title: Services
   - [[tempo]]
   - [[loki]]
   - [[pyroscope]]
+  - [[mimir]]
 - [[mailhog]]#
 - [[memcached]]#
 - [[minio]]#

--- a/nix/services/default.nix
+++ b/nix/services/default.nix
@@ -36,6 +36,7 @@ in
       ./loki.nix
       ./phpfpm.nix
       ./pubsub-emulator.nix
+      ./mimir.nix
       ./qdrant.nix
       ./chromadb.nix
       ./neo4j.nix

--- a/nix/services/mimir.nix
+++ b/nix/services/mimir.nix
@@ -1,0 +1,129 @@
+{
+  pkgs,
+  lib,
+  name,
+  config,
+  ...
+}:
+let
+  inherit (lib) types;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  options = {
+    package = lib.mkPackageOption pkgs "mimir" { };
+
+    httpAddress = lib.mkOption {
+      type = types.str;
+      description = "Which address to access mimir from.";
+      default = "127.0.0.1";
+    };
+
+    httpPort = lib.mkOption {
+      type = types.port;
+      description = "Which port to run mimir on.";
+      default = 8080; # Likely to be overridden by consumers due to likelihood of overlapping with common ports but this is the Mimir default
+    };
+
+    extraConfig = lib.mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Specify the configuration for Mimir in Nix.
+
+        See https://grafana.com/docs/mimir/latest/configure/configuration-parameters/ for available options.
+      '';
+    };
+
+    extraFlags = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = lib.literalExpression ''[ "-config.expand-env=true" ]'';
+      description = "Additional flags to pass to mimir.";
+    };
+  };
+
+  config = {
+    outputs = {
+      settings = {
+        processes."${name}" =
+          let
+            mimirConfig = lib.recursiveUpdate {
+              multitenancy_enabled = false;
+              server = {
+                http_listen_address = config.httpAddress;
+                http_listen_port = config.httpPort;
+              };
+              memberlist = {
+                bind_addr = [ config.httpAddress ];
+                advertise_addr = config.httpAddress;
+              };
+              blocks_storage = {
+                backend = "filesystem";
+                filesystem.dir = "${config.dataDir}/blocks";
+                bucket_store.sync_dir = "${config.dataDir}/tsdb-sync";
+                tsdb.dir = "${config.dataDir}/tsdb";
+              };
+              compactor = {
+                data_dir = "${config.dataDir}/compactor";
+                sharding_ring = {
+                  instance_addr = config.httpAddress;
+                  kvstore.store = "memberlist";
+                };
+              };
+              distributor.ring = {
+                instance_addr = config.httpAddress;
+                kvstore.store = "memberlist";
+              };
+              ingester.ring = {
+                instance_addr = config.httpAddress;
+                kvstore.store = "memberlist";
+                replication_factor = 1;
+              };
+              store_gateway.sharding_ring = {
+                instance_addr = config.httpAddress;
+                replication_factor = 1;
+              };
+              frontend.address = config.httpAddress;
+              ruler = {
+                rule_path = "${config.dataDir}/ruler";
+                ring.instance_addr = config.httpAddress;
+              };
+              ruler_storage = {
+                backend = "filesystem";
+                filesystem.dir = "${config.dataDir}/rules";
+              };
+            } config.extraConfig;
+            mimirConfigYaml = yamlFormat.generate "mimir.yaml" mimirConfig;
+            startScript = pkgs.writeShellApplication {
+              name = "start-mimir";
+              runtimeInputs = [ config.package ];
+              text = ''
+                exec mimir -target=all -config.file=${mimirConfigYaml} ${lib.escapeShellArgs config.extraFlags}
+              '';
+            };
+          in
+          {
+            command = startScript;
+            readiness_probe = {
+              http_get = {
+                host = config.httpAddress;
+                scheme = "http";
+                port = config.httpPort;
+                path = "/ready";
+              };
+              initial_delay_seconds = 15;
+              period_seconds = 10;
+              timeout_seconds = 2;
+              success_threshold = 1;
+              failure_threshold = 5;
+            };
+            availability = {
+              restart = "on_failure";
+              max_restarts = 5;
+            };
+          };
+      };
+    };
+  };
+}

--- a/nix/services/mimir_test.nix
+++ b/nix/services/mimir_test.nix
@@ -1,0 +1,24 @@
+{ pkgs, config, ... }:
+{
+  services.mimir."mi1" = {
+    enable = true;
+  };
+
+  settings.processes.test =
+    let
+      cfg = config.services.mimir."mi1";
+    in
+    {
+      command = pkgs.writeShellApplication {
+        runtimeInputs = [
+          pkgs.gnugrep
+          pkgs.curl
+        ];
+        text = ''
+          curl -sSfN "http://${cfg.httpAddress}:${toString cfg.httpPort}/ready" | grep "ready"
+        '';
+        name = "mimir-test";
+      };
+      depends_on."mi1".condition = "process_healthy";
+    };
+}

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -63,6 +63,7 @@
                   "${inputs.services-flake}/nix/services/grafana_test.nix"
                   "${inputs.services-flake}/nix/services/mailhog_test.nix"
                   "${inputs.services-flake}/nix/services/memcached_test.nix"
+                  "${inputs.services-flake}/nix/services/mimir_test.nix"
                   "${inputs.services-flake}/nix/services/mysql/mysql_test.nix"
                   "${inputs.services-flake}/nix/services/nats-server_test.nix"
                   "${inputs.services-flake}/nix/services/nginx/nginx_test.nix"


### PR DESCRIPTION
Adds [Mimir](https://grafana.com/oss/mimir/), a storage engine for time series data.

This PR also adds the final service required for this project to support the full LGTM observability stack