### PR TITLE
fix(pyroscope): readiness failure

### DIFF
--- a/nix/services/pyroscope.nix
+++ b/nix/services/pyroscope.nix
@@ -92,7 +92,7 @@ in
               period_seconds = 10;
               timeout_seconds = 2;
               success_threshold = 1;
-              failure_threshold = 5;
+              failure_threshold = 15;
             };
             availability = {
               restart = "on_failure";


### PR DESCRIPTION
Pyroscope 2.0 performs extra start up steps that pushes the boundaries of the readiness probes that the module currently has in place. 

The changes included increases the `failure_threshold` -> 15. I chose not to increase the initial_delay_seconds as I can't substantively say that a more powerful machine couldn't complete some of the init process faster