### PR TITLE
Add `live_store` configuration for Tempo v3

### DIFF
--- a/nix/services/tempo.nix
+++ b/nix/services/tempo.nix
@@ -65,6 +65,13 @@ in
                     local = {
                       path = "${config.dataDir}/blocks";
                     };
+                  }
+                  # The live_store block is only supported by Tempo 3.x and later.
+                  // lib.optionalAttrs (lib.versionAtLeast config.package.version "3") {
+                    live_store = {
+                      shutdown_marker_dir = "${config.dataDir}/live-store/shutdown-marker";
+                      wal.path = "${config.dataDir}/live-store/traces";
+                    };
                   };
                 };
               }


### PR DESCRIPTION
Tempo v3 added `live_store` as a configurable field which has two directory path sub-fields. Consumers of this module currently have to set this themselves if they are using a version of nixpkgs that ships v3. This pull request resolves that issue by adding a version guard that conditionally adds the `live_store` block for any consumers of this module using Tempo v3