### PR TITLE
Fix Tempo `live_store` config appending to `storage` field

### DIFF
--- a/nix/services/tempo.nix
+++ b/nix/services/tempo.nix
@@ -55,30 +55,32 @@ in
       settings = {
         processes."${name}" =
           let
-            tempoConfig = lib.recursiveUpdate {
-              server = {
-                http_listen_address = config.httpAddress;
-                http_listen_port = config.httpPort;
-              };
-              storage = {
-                trace = {
-                  backend = "local";
-                  wal = {
-                    path = "${config.dataDir}/wal";
-                  };
-                  local = {
-                    path = "${config.dataDir}/blocks";
-                  };
-                }
-                # The live_store block is only supported by Tempo 3.x and later.
-                // lib.optionalAttrs (lib.versionAtLeast config.package.version "3") {
-                  live_store = {
-                    shutdown_marker_dir = "${config.dataDir}/live-store/shutdown-marker";
-                    wal.path = "${config.dataDir}/live-store/traces";
+            tempoConfig = lib.recursiveUpdate (
+              {
+                server = {
+                  http_listen_address = config.httpAddress;
+                  http_listen_port = config.httpPort;
+                };
+                storage = {
+                  trace = {
+                    backend = "local";
+                    wal = {
+                      path = "${config.dataDir}/wal";
+                    };
+                    local = {
+                      path = "${config.dataDir}/blocks";
+                    };
                   };
                 };
-              };
-            } config.extraConfig;
+              }
+              # `live_store` is a top-level config field only supported by Tempo 3.x and later.
+              // lib.optionalAttrs (lib.versionAtLeast config.package.version "3") {
+                live_store = {
+                  shutdown_marker_dir = "${config.dataDir}/live-store/shutdown-marker";
+                  wal.path = "${config.dataDir}/live-store/traces";
+                };
+              }
+            ) config.extraConfig;
             tempoConfigYaml = yamlFormat.generate "tempo.yaml" tempoConfig;
             startScript = pkgs.writeShellApplication {
               name = "start-tempo";


### PR DESCRIPTION
The `live_store` field in Tempo currently incorrectly appends to the `storage` block instead of the top level. This went uncaught because of the conditional addition of it which this repo doesn't currently trigger.

This is a regression from https://github.com/juspay/services-flake/pull/716